### PR TITLE
Update version number from 'nightly' to '1.0' in altstore.json

### DIFF
--- a/altstore.json
+++ b/altstore.json
@@ -18,7 +18,7 @@
             "screenshotURLs": [],
             "versions": [
                 {
-                  "version": "nightly",
+                  "version": "1.0",
                   "date": "2024-11-24",
                   "downloadURL": "https://github.com/hugeBlack/OpenParsec/releases/download/nightly/OpenParsec.ipa",
                   "size": 1800157


### PR DESCRIPTION
When it was set to 'nightly', it would cause an error in AltStore stating that it was expecting version number '1.0'