### PR TITLE
Move zoom reset on rotate

### DIFF
--- a/OpenParsec/ParsecViewController.swift
+++ b/OpenParsec/ParsecViewController.swift
@@ -267,13 +267,13 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate {
 		let h = size.height
 		let w = size.width
 		
+		// Reset zoom on rotation
+		scrollView.zoomScale = 1.0
+
 		self.glkView.updateSize(width: w, height: h)
 		contentView.frame.size = CGSize(width: w, height: h)
 		scrollView.contentSize = CGSize(width: w, height: h)
 		CParsec.setFrame(w, h, UIScreen.main.scale)
-
-		// Reset zoom on rotation
-		scrollView.zoomScale = 1.0
         
         // Reset accessory view to ensure correct width in new orientation
         keyboardAccessoriesView = nil


### PR DESCRIPTION
Rotating the phone after zooming was causing issues preventing the screen to follow the cursor, it is resolved on my iPhone 16

Moving the zoom reset to before the viewport resizing logic resolves the issue