### PR TITLE
keyboard remap and key repeat for hardware keyboards

### DIFF
--- a/OpenParsec/CParsec.swift
+++ b/OpenParsec/CParsec.swift
@@ -151,6 +151,7 @@ protocol ParsecService {
 	func sendMouseDelta(_ dx: Int32, _ dy: Int32)
 	func sendMousePosition(_ x: Int32, _ y: Int32)
 	func sendKeyboardMessage(event: KeyBoardKeyEvent)
+	func sendKeyboardMessage(keyCode: UInt32, pressed: Bool)
 	func sendVirtualKeyboardInput(text: String)
 	func sendVirtualKeyboardInput(text: String, isOn: Bool)
 	func sendGameControllerButtonMessage(controllerId: UInt32, _ button: ParsecGamepadButton, pressed: Bool)
@@ -261,7 +262,12 @@ class CParsec
 	{
 		parsecImpl.sendKeyboardMessage(event: event)
 	}
-	
+
+	static func sendKeyboardMessage(keyCode: UInt32, pressed: Bool)
+	{
+		parsecImpl.sendKeyboardMessage(keyCode: keyCode, pressed: pressed)
+	}
+
 	static func sendVirtualKeyboardInput(text: String) {
 		parsecImpl.sendVirtualKeyboardInput(text: text)
 	}

--- a/OpenParsec/ParsecSDKBridge.swift
+++ b/OpenParsec/ParsecSDKBridge.swift
@@ -437,11 +437,20 @@ class ParsecSDKBridge: ParsecService
 		if event.input == nil {
 			return
 		}
-		
+
 		var keyboardMessagePress = ParsecMessage()
 		keyboardMessagePress.type = MESSAGE_KEYBOARD
 		keyboardMessagePress.keyboard.code = ParsecKeycode(UInt32(KeyCodeTranslators.uiKeyCodeToInt(key: event.input?.keyCode ?? UIKeyboardHIDUsage.keyboardErrorUndefined)))
 		keyboardMessagePress.keyboard.pressed = event.isPressBegin
+		ParsecClientSendMessage(_parsec, &keyboardMessagePress)
+	}
+
+	func sendKeyboardMessage(keyCode: UInt32, pressed: Bool)
+	{
+		var keyboardMessagePress = ParsecMessage()
+		keyboardMessagePress.type = MESSAGE_KEYBOARD
+		keyboardMessagePress.keyboard.code = ParsecKeycode(keyCode)
+		keyboardMessagePress.keyboard.pressed = pressed
 		ParsecClientSendMessage(_parsec, &keyboardMessagePress)
 	}
 	

--- a/OpenParsec/ParsecViewController.swift
+++ b/OpenParsec/ParsecViewController.swift
@@ -312,20 +312,100 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate {
 	}
 	
 	
+	private var repeatTimer: Timer?
+	private var repeatKeyCode: Int = -1
+	private var optCmdRemapActive = false
+	private var altKeyHeld = false
+
 	override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
-		
 		for press in presses {
-			CParsec.sendKeyboardMessage(event:KeyBoardKeyEvent(input: press.key, isPressBegin: true) )
+			guard let key = press.key else { continue }
+
+			if key.keyCode == .keyboardLeftAlt || key.keyCode == .keyboardRightAlt {
+				altKeyHeld = true
+			}
+
+			if !isModifierKey(key.keyCode) && (altKeyHeld || key.modifierFlags.contains(.alternate)) {
+				if !optCmdRemapActive {
+					CParsec.sendKeyboardMessage(keyCode: 226, pressed: false)
+					CParsec.sendKeyboardMessage(keyCode: 227, pressed: true)
+					optCmdRemapActive = true
+				}
+				let code = KeyCodeTranslators.uiKeyCodeToInt(key: key.keyCode)
+				CParsec.sendKeyboardMessage(keyCode: UInt32(code), pressed: true)
+				startKeyRepeat(keyCode: code)
+				continue
+			}
+
+			CParsec.sendKeyboardMessage(event:KeyBoardKeyEvent(input: press.key, isPressBegin: true))
+
+			if !isModifierKey(key.keyCode) {
+				startKeyRepeat(keyCode: KeyCodeTranslators.uiKeyCodeToInt(key: key.keyCode))
+			}
 		}
-		
 	}
-	
-	override func pressesEnded (_ presses: Set<UIPress>, with event: UIPressesEvent?) {
-		
+
+	override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
 		for press in presses {
-			CParsec.sendKeyboardMessage(event:KeyBoardKeyEvent(input: press.key, isPressBegin: false) )
+			guard let key = press.key else { continue }
+
+			if optCmdRemapActive {
+				if key.keyCode == .keyboardLeftAlt || key.keyCode == .keyboardRightAlt {
+					altKeyHeld = false
+					CParsec.sendKeyboardMessage(keyCode: 227, pressed: false)
+					optCmdRemapActive = false
+					continue
+				}
+				if !isModifierKey(key.keyCode) {
+					let code = KeyCodeTranslators.uiKeyCodeToInt(key: key.keyCode)
+					CParsec.sendKeyboardMessage(keyCode: UInt32(code), pressed: false)
+					if code == repeatKeyCode { stopKeyRepeat() }
+					continue
+				}
+			}
+
+			if key.keyCode == .keyboardLeftAlt || key.keyCode == .keyboardRightAlt {
+				altKeyHeld = false
+			}
+
+			CParsec.sendKeyboardMessage(event:KeyBoardKeyEvent(input: press.key, isPressBegin: false))
+
+			let code = KeyCodeTranslators.uiKeyCodeToInt(key: key.keyCode)
+			if code == repeatKeyCode {
+				stopKeyRepeat()
+			}
 		}
-		
+	}
+
+	private func startKeyRepeat(keyCode: Int) {
+		stopKeyRepeat()
+		repeatKeyCode = keyCode
+
+		repeatTimer = Timer.scheduledTimer(withTimeInterval: 0.4, repeats: false) { [weak self] _ in
+			guard let self = self else { return }
+			self.repeatTimer = Timer.scheduledTimer(withTimeInterval: 0.033, repeats: true) { [weak self] _ in
+				guard let self = self else { return }
+				CParsec.sendKeyboardMessage(keyCode: UInt32(self.repeatKeyCode), pressed: false)
+				CParsec.sendKeyboardMessage(keyCode: UInt32(self.repeatKeyCode), pressed: true)
+			}
+		}
+	}
+
+	private func stopKeyRepeat() {
+		repeatTimer?.invalidate()
+		repeatTimer = nil
+		repeatKeyCode = -1
+	}
+
+	private func isModifierKey(_ keyCode: UIKeyboardHIDUsage) -> Bool {
+		switch keyCode {
+		case .keyboardLeftControl, .keyboardLeftShift, .keyboardLeftAlt, .keyboardLeftGUI,
+			 .keyboardRightControl, .keyboardRightShift, .keyboardRightAlt, .keyboardRightGUI,
+			 .keyboardCapsLock:
+			return true
+		default:
+			return false
+		}
 	}
 	
 	@objc func keyboardWillShow(notification: NSNotification) {


### PR DESCRIPTION
close #54
ios strips the modifier flag on dead keys like opt+backtick.
ipad intercepts cmd+tab/space/h at the system level so they never reach the app.
this pr remaps opt to cmd on the host side, so opt+tab in client does cmd+tab on host

also added client side key repeat (eg, long press backspace
