### PR TITLE
reduce battery drain

### DIFF
--- a/OpenParsec/ParsecSDKBridge.swift
+++ b/OpenParsec/ParsecSDKBridge.swift
@@ -53,7 +53,8 @@ class ParsecSDKBridge: ParsecService
 	public var netProtocol: Int32 = 1
 	public var mediaContainer: Int32 = 0
 	public var pngCursor: Bool = false
-	var backgroundTaskRunning = true
+	private var audioWork: DispatchWorkItem?
+	private var eventWork: DispatchWorkItem?
 	var didSetResolution = false
 	
 	public var mouseInfo = MouseInfo()
@@ -124,11 +125,12 @@ class ParsecSDKBridge: ParsecService
 	}
 	
 	func disconnect() {
-		
+
+		audioWork?.cancel()
+		eventWork?.cancel()
 		audio_clear(&_audio)
 		ParsecClientDisconnect(_parsec)
-		backgroundTaskRunning = false
-		
+
 		ParsecBackgroundManager.shared.connectionDidEnd()
 	}
 	
@@ -490,28 +492,25 @@ class ParsecSDKBridge: ParsecService
 		pmsg.mouseWheel.y = y
 		ParsecClientSendMessage(_parsec, &pmsg)
 	}
-	
-	func startBackgroundTask(){
-	
-		
-		let item1 = DispatchWorkItem {
-			while self.backgroundTaskRunning {
+
+	func startBackgroundTask() {
+
+		let audio = DispatchWorkItem { [weak self] in
+			while let self = self, !(self.audioWork?.isCancelled ?? true) {
 				self.pollAudio()
 			}
-			
 		}
 
-		let item2 = DispatchWorkItem {
-			while self.backgroundTaskRunning {
+		let event = DispatchWorkItem { [weak self] in
+			while let self = self, !(self.eventWork?.isCancelled ?? true) {
 				self.pollEvent()
-	
-				
 			}
-			
 		}
-		let mainQueue = DispatchQueue.global()
-		mainQueue.async(execute: item1)
-		mainQueue.async(execute: item2)
+
+		audioWork = audio
+		eventWork = event
+		DispatchQueue.global().async(execute: audio)
+		DispatchQueue.global().async(execute: event)
 	}
 	
 	func sendUserData(type: ParsecUserDataType, message: Data) {

--- a/OpenParsec/ParsecView.swift
+++ b/OpenParsec/ParsecView.swift
@@ -10,7 +10,7 @@ struct ParsecStatusBar : View {
 	@Binding var DCAlertText: String
 	@State var parsecViewController: ParsecViewController?
 	@State var wasDisconnected: Bool = true
-	let timer = Timer.publish(every: 0.2, on: .main, in: .common).autoconnect()
+	let timer = Timer.publish(every: 1.0, on: .main, in: .common).autoconnect()
 
 	init(showMenu: Binding<Bool>, showDCAlert: Binding<Bool>, DCAlertText: Binding<String>, parsecViewController: ParsecViewController) {
 		_showMenu = showMenu


### PR DESCRIPTION
status poll was firing every 5x/sec even when the menu wasnt open, dropped it to 1s

on background thread lifecycle on disconnect, the old code used a plain bool flag that the polling threads may never see due to data races. replaced with DispatchWorkItem and cancel on disconnect so threads actually stop