### PR TITLE
pause on background instead of disconnecting

### DIFF
--- a/OpenParsec/CParsec.swift
+++ b/OpenParsec/CParsec.swift
@@ -158,6 +158,7 @@ protocol ParsecService {
 	func sendGameControllerUnplugMessage(controllerId: UInt32)
 	func sendWheelMsg(x: Int32, y: Int32)
 	func sendUserData(type: ParsecUserDataType, message: Data)
+	func sendReleaseMessage()
 	func updateHostVideoConfig()
 }
 
@@ -293,7 +294,11 @@ class CParsec
 	static func sendUserData(type: ParsecUserDataType, message: Data) {
 		parsecImpl.sendUserData(type: type, message: message)
 	}
-	
+
+	static func sendReleaseMessage() {
+		parsecImpl.sendReleaseMessage()
+	}
+
 	static func getImpl() -> ParsecService {
 		return parsecImpl
 	}

--- a/OpenParsec/CParsec.swift
+++ b/OpenParsec/CParsec.swift
@@ -159,6 +159,8 @@ protocol ParsecService {
 	func sendWheelMsg(x: Int32, y: Int32)
 	func sendUserData(type: ParsecUserDataType, message: Data)
 	func sendReleaseMessage()
+	func pause(video: Bool, audio: Bool) -> ParsecStatus
+	func resume() -> ParsecStatus
 	func updateHostVideoConfig()
 }
 
@@ -297,6 +299,14 @@ class CParsec
 
 	static func sendReleaseMessage() {
 		parsecImpl.sendReleaseMessage()
+	}
+
+	static func pause(video: Bool = true, audio: Bool = true) -> ParsecStatus {
+		return parsecImpl.pause(video: video, audio: audio)
+	}
+
+	static func resume() -> ParsecStatus {
+		return parsecImpl.resume()
 	}
 
 	static func getImpl() -> ParsecService {

--- a/OpenParsec/CParsec.swift
+++ b/OpenParsec/CParsec.swift
@@ -158,6 +158,7 @@ protocol ParsecService {
 	func sendGameControllerUnplugMessage(controllerId: UInt32)
 	func sendWheelMsg(x: Int32, y: Int32)
 	func sendUserData(type: ParsecUserDataType, message: Data)
+	func sendReleaseMessage()
 	func updateHostVideoConfig()
 }
 
@@ -277,6 +278,10 @@ class CParsec {
 
 	static func sendUserData(type: ParsecUserDataType, message: Data) {
 		parsecImpl.sendUserData(type: type, message: message)
+	}
+
+	static func sendReleaseMessage() {
+		parsecImpl.sendReleaseMessage()
 	}
 
 	static func getImpl() -> ParsecService {

--- a/OpenParsec/CParsec.swift
+++ b/OpenParsec/CParsec.swift
@@ -286,10 +286,12 @@ class CParsec {
 		parsecImpl.sendReleaseMessage()
 	}
 
+	@discardableResult
 	static func pause(video: Bool = true, audio: Bool = true) -> ParsecStatus {
 		return parsecImpl.pause(video: video, audio: audio)
 	}
 
+	@discardableResult
 	static func resume() -> ParsecStatus {
 		return parsecImpl.resume()
 	}

--- a/OpenParsec/CParsec.swift
+++ b/OpenParsec/CParsec.swift
@@ -159,6 +159,8 @@ protocol ParsecService {
 	func sendWheelMsg(x: Int32, y: Int32)
 	func sendUserData(type: ParsecUserDataType, message: Data)
 	func sendReleaseMessage()
+	func pause(video: Bool, audio: Bool) -> ParsecStatus
+	func resume() -> ParsecStatus
 	func updateHostVideoConfig()
 }
 
@@ -282,6 +284,14 @@ class CParsec {
 
 	static func sendReleaseMessage() {
 		parsecImpl.sendReleaseMessage()
+	}
+
+	static func pause(video: Bool = true, audio: Bool = true) -> ParsecStatus {
+		return parsecImpl.pause(video: video, audio: audio)
+	}
+
+	static func resume() -> ParsecStatus {
+		return parsecImpl.resume()
 	}
 
 	static func getImpl() -> ParsecService {

--- a/OpenParsec/ParsecBackgroundManager.swift
+++ b/OpenParsec/ParsecBackgroundManager.swift
@@ -1,5 +1,6 @@
 import UIKit
 import AVFoundation
+import GLKit
 
 class ParsecBackgroundManager {
 	static let shared = ParsecBackgroundManager()
@@ -9,6 +10,7 @@ class ParsecBackgroundManager {
 	private var didDisconnectDueToBackground = false
 	private(set) var isReconnecting = false
 	var isPaused = false
+	weak var glkViewController: GLKViewController?
 
 	var onShouldReconnect: ((String) -> Void)?
 	var onShouldDisconnect: (() -> Void)?
@@ -54,7 +56,7 @@ class ParsecBackgroundManager {
 	}
 
 	func sceneDidEnterBackground() {
-		if hasActiveConnection {
+		if hasActiveConnection && !isPaused {
 			var pipAttempted = false
 			if #available(iOS 15.0, *) {
 				pipAttempted = isPiPActive || PictureInPictureManager.shared.isStarting

--- a/OpenParsec/ParsecBackgroundManager.swift
+++ b/OpenParsec/ParsecBackgroundManager.swift
@@ -8,6 +8,7 @@ class ParsecBackgroundManager {
 	private var lastPeerId: String?
 	private var didDisconnectDueToBackground = false
 	private(set) var isReconnecting = false
+	var isPaused = false
 
 	var onShouldReconnect: ((String) -> Void)?
 	var onShouldDisconnect: (() -> Void)?

--- a/OpenParsec/ParsecBackgroundManager.swift
+++ b/OpenParsec/ParsecBackgroundManager.swift
@@ -34,10 +34,12 @@ class ParsecBackgroundManager {
 		lastPeerId = peerId
 		didDisconnectDueToBackground = false
 		isReconnecting = false
+		isPaused = false
 	}
 
 	func connectionDidEnd() {
 		hasActiveConnection = false
+		isPaused = false
 	}
 
 	func sceneWillResignActive() {

--- a/OpenParsec/ParsecGLKRenderer.swift
+++ b/OpenParsec/ParsecGLKRenderer.swift
@@ -30,8 +30,8 @@ class ParsecGLKRenderer:NSObject, GLKViewDelegate, GLKViewControllerDelegate
 		glkViewController.delegate = nil
 	}
 
-	func glkView(_ view:GLKView, drawIn rect:CGRect)
-	{
+	func glkView(_ view: GLKView, drawIn rect: CGRect) {
+		if glkViewController.isPaused { return }
 		let deltaWidth: CGFloat = view.frame.size.width - lastWidth
 		if deltaWidth > 0.1 || deltaWidth < -0.1
 		{

--- a/OpenParsec/ParsecGLKRenderer.swift
+++ b/OpenParsec/ParsecGLKRenderer.swift
@@ -29,6 +29,7 @@ class ParsecGLKRenderer: NSObject, GLKViewDelegate, GLKViewControllerDelegate {
 	}
 
 	func glkView(_ view: GLKView, drawIn rect: CGRect) {
+		if glkViewController.isPaused { return }
 		let deltaWidth: CGFloat = view.frame.size.width - lastWidth
 		if deltaWidth > 0.1 || deltaWidth < -0.1 {
 		    CParsec.setFrame(view.frame.size.width, view.frame.size.height, view.contentScaleFactor)

--- a/OpenParsec/ParsecGLKViewController.swift
+++ b/OpenParsec/ParsecGLKViewController.swift
@@ -45,7 +45,7 @@ class ParsecGLKViewController : ParsecPlayground {
 		glkRenderer = ParsecGLKRenderer(glkView, glkViewController, updateImage)
 		self.viewController.view.addSubview(glkView)
 		setupGLKViewController()
-		
+		ParsecBackgroundManager.shared.glkViewController = glkViewController
 
 	}
 

--- a/OpenParsec/ParsecGLKViewController.swift
+++ b/OpenParsec/ParsecGLKViewController.swift
@@ -45,6 +45,7 @@ class ParsecGLKViewController: ParsecPlayground {
 		glkRenderer = ParsecGLKRenderer(glkView, glkViewController, updateImage)
 		self.viewController.view.addSubview(glkView)
 		setupGLKViewController()
+		ParsecBackgroundManager.shared.glkViewController = glkViewController
 
 	}
 

--- a/OpenParsec/ParsecSDKBridge.swift
+++ b/OpenParsec/ParsecSDKBridge.swift
@@ -124,11 +124,11 @@ class ParsecSDKBridge: ParsecService
 	}
 	
 	func disconnect() {
-		
-		audio_clear(&_audio)
+
 		ParsecClientDisconnect(_parsec)
+		audio_clear(&_audio)
 		backgroundTaskRunning = false
-		
+
 		ParsecBackgroundManager.shared.connectionDidEnd()
 	}
 

--- a/OpenParsec/ParsecSDKBridge.swift
+++ b/OpenParsec/ParsecSDKBridge.swift
@@ -138,6 +138,14 @@ class ParsecSDKBridge: ParsecService
 		ParsecClientSendMessage(_parsec, &msg)
 	}
 
+	func pause(video: Bool = true, audio: Bool = true) -> ParsecStatus {
+		return ParsecClientPause(_parsec, video, audio)
+	}
+
+	func resume() -> ParsecStatus {
+		return ParsecClientPause(_parsec, false, false)
+	}
+
 	func getStatus() -> ParsecStatus {
 		
 		return ParsecClientGetStatus(_parsec, nil)

--- a/OpenParsec/ParsecSDKBridge.swift
+++ b/OpenParsec/ParsecSDKBridge.swift
@@ -131,7 +131,13 @@ class ParsecSDKBridge: ParsecService
 		
 		ParsecBackgroundManager.shared.connectionDidEnd()
 	}
-	
+
+	func sendReleaseMessage() {
+		var msg = ParsecMessage()
+		msg.type = MESSAGE_RELEASE
+		ParsecClientSendMessage(_parsec, &msg)
+	}
+
 	func getStatus() -> ParsecStatus {
 		
 		return ParsecClientGetStatus(_parsec, nil)

--- a/OpenParsec/ParsecSDKBridge.swift
+++ b/OpenParsec/ParsecSDKBridge.swift
@@ -122,8 +122,8 @@ class ParsecSDKBridge: ParsecService {
 
 		audioWork?.cancel()
 		eventWork?.cancel()
-		audio_clear(&_audio)
 		ParsecClientDisconnect(_parsec)
+		audio_clear(&_audio)
 
 		ParsecBackgroundManager.shared.connectionDidEnd()
 	}

--- a/OpenParsec/ParsecSDKBridge.swift
+++ b/OpenParsec/ParsecSDKBridge.swift
@@ -134,6 +134,14 @@ class ParsecSDKBridge: ParsecService {
 		ParsecClientSendMessage(_parsec, &msg)
 	}
 
+	func pause(video: Bool = true, audio: Bool = true) -> ParsecStatus {
+		return ParsecClientPause(_parsec, video, audio)
+	}
+
+	func resume() -> ParsecStatus {
+		return ParsecClientPause(_parsec, false, false)
+	}
+
 	func getStatus() -> ParsecStatus {
 
 		return ParsecClientGetStatus(_parsec, nil)

--- a/OpenParsec/ParsecSDKBridge.swift
+++ b/OpenParsec/ParsecSDKBridge.swift
@@ -128,6 +128,12 @@ class ParsecSDKBridge: ParsecService {
 		ParsecBackgroundManager.shared.connectionDidEnd()
 	}
 
+	func sendReleaseMessage() {
+		var msg = ParsecMessage()
+		msg.type = MESSAGE_RELEASE
+		ParsecClientSendMessage(_parsec, &msg)
+	}
+
 	func getStatus() -> ParsecStatus {
 
 		return ParsecClientGetStatus(_parsec, nil)

--- a/OpenParsec/ParsecSDKBridge.swift
+++ b/OpenParsec/ParsecSDKBridge.swift
@@ -134,10 +134,12 @@ class ParsecSDKBridge: ParsecService {
 		ParsecClientSendMessage(_parsec, &msg)
 	}
 
+	@discardableResult
 	func pause(video: Bool = true, audio: Bool = true) -> ParsecStatus {
 		return ParsecClientPause(_parsec, video, audio)
 	}
 
+	@discardableResult
 	func resume() -> ParsecStatus {
 		return ParsecClientPause(_parsec, false, false)
 	}

--- a/OpenParsec/ParsecView.swift
+++ b/OpenParsec/ParsecView.swift
@@ -458,6 +458,7 @@ struct ParsecView: View
 			PictureInPictureManager.shared.teardown()
 		}
 
+		CParsec.sendReleaseMessage()
 		CParsec.disconnect()
 		self.parsecViewController.glkView.cleanUp()
 

--- a/OpenParsec/ParsecView.swift
+++ b/OpenParsec/ParsecView.swift
@@ -42,12 +42,10 @@ struct ParsecStatusBar : View {
 				poll()
 			}
 	}
-	
-	func poll()
-	{
-		if showDCAlert
-		{
-			return // no need to poll if we aren't connected anymore
+
+	func poll() {
+		if showDCAlert || ParsecBackgroundManager.shared.isPaused {
+			return
 		}
 		
 		var pcs = ParsecClientStatus()

--- a/OpenParsec/ParsecView.swift
+++ b/OpenParsec/ParsecView.swift
@@ -21,10 +21,8 @@ struct ParsecStatusBar : View {
 	
 	var body: some View {
 		// Overlay elements
-		if showMenu
-		{
-			VStack()
-			{
+		if showMenu || SettingsHandler.alwaysShowStatus {
+			VStack {
 				Text(metricInfo)
 					.frame(minWidth:200, maxWidth:.infinity, maxHeight:20)
 					.multilineTextAlignment(.leading)
@@ -81,11 +79,10 @@ struct ParsecStatusBar : View {
 			showDCAlert = true
 			return
 		}
-		
-		if showMenu
-		{
-			let str = String.fromBuffer(&pcs.decoder.0.name.0, length:16)
-			metricInfo = "Decode \(String(format:"%.2f", pcs.`self`.metrics.0.decodeLatency))ms    Encode \(String(format:"%.2f", pcs.`self`.metrics.0.encodeLatency))ms    Network \(String(format:"%.2f", pcs.`self`.metrics.0.networkLatency))ms    Bitrate \(String(format:"%.2f", pcs.`self`.metrics.0.bitrate))Mbps    \(pcs.decoder.0.h265 ? "H265" : "H264") \(pcs.decoder.0.width)x\(pcs.decoder.0.height) \(pcs.decoder.0.color444 ? "4:4:4" : "4:2:0") \(str)"
+
+		if showMenu || SettingsHandler.alwaysShowStatus {
+			let str = String.fromBuffer(&pcs.decoder.0.name.0, length: 16)
+			metricInfo = "Decode \(String(format: "%.2f", pcs.`self`.metrics.0.decodeLatency))ms    Encode \(String(format: "%.2f", pcs.`self`.metrics.0.encodeLatency))ms    Network \(String(format: "%.2f", pcs.`self`.metrics.0.networkLatency))ms    Bitrate \(String(format: "%.2f", pcs.`self`.metrics.0.bitrate))Mbps    \(pcs.decoder.0.h265 ? "H265" : "H264") \(pcs.decoder.0.width)x\(pcs.decoder.0.height) \(pcs.decoder.0.color444 ? "4:4:4" : "4:2:0") \(str)"
 		}
 	}
 }

--- a/OpenParsec/ParsecView.swift
+++ b/OpenParsec/ParsecView.swift
@@ -349,13 +349,9 @@ struct ParsecView: View
 		if #available(iOS 15.0, *) {
 			PictureInPictureManager.shared.onPiPStopped = { [self] in
 				if UIApplication.shared.applicationState != .active {
-					// Synchronous — DispatchQueue.main.async may never execute if iOS suspends the app
-					CParsec.disconnect()
-					try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
-					ParsecBackgroundManager.shared.markForReconnect()
-					DispatchQueue.main.async {
-						self.disconnect(isBackgroundDisconnect: true)
-					}
+					CParsec.sendReleaseMessage()
+					CParsec.pause()
+					ParsecBackgroundManager.shared.isPaused = true
 				} else {
 					if ParsecBackgroundManager.shared.isReconnecting {
 						return
@@ -373,12 +369,11 @@ struct ParsecView: View
 					}
 				}
 			}
-			PictureInPictureManager.shared.onPiPStartFailed = { [self] in
+			PictureInPictureManager.shared.onPiPStartFailed = {
 				if UIApplication.shared.applicationState != .active {
-					ParsecBackgroundManager.shared.markForReconnect()
-					DispatchQueue.main.async {
-						self.disconnect(isBackgroundDisconnect: true)
-					}
+					CParsec.sendReleaseMessage()
+					CParsec.pause()
+					ParsecBackgroundManager.shared.isPaused = true
 				}
 			}
 		}

--- a/OpenParsec/ParsecView.swift
+++ b/OpenParsec/ParsecView.swift
@@ -417,6 +417,7 @@ struct ParsecView: View
 	{
 		muted.toggle()
 		CParsec.setMuted(muted)
+		muted ? CParsec.pause(video: false, audio: true) : CParsec.resume()
 		if SettingsHandler.saveSessionSettings { SettingsHandler.savedMuted = muted }
 	}
 

--- a/OpenParsec/ParsecView.swift
+++ b/OpenParsec/ParsecView.swift
@@ -387,7 +387,11 @@ struct ParsecView: View {
 	func toggleMute() {
 		muted.toggle()
 		CParsec.setMuted(muted)
-		muted ? CParsec.pause(video: false, audio: true) : CParsec.resume()
+		if muted {
+			CParsec.pause(video: false, audio: true)
+		} else {
+			CParsec.resume()
+		}
 		if SettingsHandler.saveSessionSettings { SettingsHandler.savedMuted = muted }
 	}
 

--- a/OpenParsec/ParsecView.swift
+++ b/OpenParsec/ParsecView.swift
@@ -427,6 +427,7 @@ struct ParsecView: View {
 			PictureInPictureManager.shared.teardown()
 		}
 
+		CParsec.sendReleaseMessage()
 		CParsec.disconnect()
 		self.parsecViewController.glkView.cleanUp()
 

--- a/OpenParsec/ParsecView.swift
+++ b/OpenParsec/ParsecView.swift
@@ -21,7 +21,7 @@ struct ParsecStatusBar: View {
 
 	var body: some View {
 		// Overlay elements
-		if showMenu {
+		if showMenu || SettingsHandler.alwaysShowStatus {
 			VStack {
 				Text(metricInfo)
 					.frame(minWidth: 200, maxWidth: .infinity, maxHeight: 20)
@@ -77,7 +77,7 @@ struct ParsecStatusBar: View {
 			return
 		}
 
-		if showMenu {
+		if showMenu || SettingsHandler.alwaysShowStatus {
 			let str = String.fromBuffer(&pcs.decoder.0.name.0, length: 16)
 			metricInfo = "Decode \(String(format: "%.2f", pcs.`self`.metrics.0.decodeLatency))ms    Encode \(String(format: "%.2f", pcs.`self`.metrics.0.encodeLatency))ms    Network \(String(format: "%.2f", pcs.`self`.metrics.0.networkLatency))ms    Bitrate \(String(format: "%.2f", pcs.`self`.metrics.0.bitrate))Mbps    \(pcs.decoder.0.h265 ? "H265" : "H264") \(pcs.decoder.0.width)x\(pcs.decoder.0.height) \(pcs.decoder.0.color444 ? "4:4:4" : "4:2:0") \(str)"
 		}

--- a/OpenParsec/ParsecView.swift
+++ b/OpenParsec/ParsecView.swift
@@ -44,8 +44,8 @@ struct ParsecStatusBar: View {
 	}
 
 	func poll() {
-		if showDCAlert {
-			return // no need to poll if we aren't connected anymore
+		if showDCAlert || ParsecBackgroundManager.shared.isPaused {
+			return
 		}
 
 		var pcs = ParsecClientStatus()

--- a/OpenParsec/ParsecView.swift
+++ b/OpenParsec/ParsecView.swift
@@ -325,6 +325,7 @@ struct ParsecView: View {
 		if #available(iOS 15.0, *) {
 			PictureInPictureManager.shared.onPiPStopped = { [self] in
 				if UIApplication.shared.applicationState != .active {
+					ParsecBackgroundManager.shared.glkViewController?.isPaused = true
 					CParsec.sendReleaseMessage()
 					CParsec.pause()
 					ParsecBackgroundManager.shared.isPaused = true
@@ -347,6 +348,7 @@ struct ParsecView: View {
 			}
 			PictureInPictureManager.shared.onPiPStartFailed = {
 				if UIApplication.shared.applicationState != .active {
+					ParsecBackgroundManager.shared.glkViewController?.isPaused = true
 					CParsec.sendReleaseMessage()
 					CParsec.pause()
 					ParsecBackgroundManager.shared.isPaused = true

--- a/OpenParsec/ParsecView.swift
+++ b/OpenParsec/ParsecView.swift
@@ -390,6 +390,7 @@ struct ParsecView: View {
 	func toggleMute() {
 		muted.toggle()
 		CParsec.setMuted(muted)
+		muted ? CParsec.pause(video: false, audio: true) : CParsec.resume()
 		if SettingsHandler.saveSessionSettings { SettingsHandler.savedMuted = muted }
 	}
 

--- a/OpenParsec/ParsecView.swift
+++ b/OpenParsec/ParsecView.swift
@@ -325,13 +325,9 @@ struct ParsecView: View {
 		if #available(iOS 15.0, *) {
 			PictureInPictureManager.shared.onPiPStopped = { [self] in
 				if UIApplication.shared.applicationState != .active {
-					// Synchronous — DispatchQueue.main.async may never execute if iOS suspends the app
-					CParsec.disconnect()
-					try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
-					ParsecBackgroundManager.shared.markForReconnect()
-					DispatchQueue.main.async {
-						self.disconnect(isBackgroundDisconnect: true)
-					}
+					CParsec.sendReleaseMessage()
+					CParsec.pause()
+					ParsecBackgroundManager.shared.isPaused = true
 				} else {
 					if ParsecBackgroundManager.shared.isReconnecting {
 						return
@@ -349,12 +345,11 @@ struct ParsecView: View {
 					}
 				}
 			}
-			PictureInPictureManager.shared.onPiPStartFailed = { [self] in
+			PictureInPictureManager.shared.onPiPStartFailed = {
 				if UIApplication.shared.applicationState != .active {
-					ParsecBackgroundManager.shared.markForReconnect()
-					DispatchQueue.main.async {
-						self.disconnect(isBackgroundDisconnect: true)
-					}
+					CParsec.sendReleaseMessage()
+					CParsec.pause()
+					ParsecBackgroundManager.shared.isPaused = true
 				}
 			}
 		}

--- a/OpenParsec/ParsecViewController.swift
+++ b/OpenParsec/ParsecViewController.swift
@@ -197,7 +197,8 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate {
 		}
 
 		if #available(iOS 15.0, *) {
-			if let parsecGLK = glkView as? ParsecGLKViewController,
+			if SettingsHandler.enablePiP,
+			   let parsecGLK = glkView as? ParsecGLKViewController,
 			   let eaglContext = parsecGLK.eaglContext {
 				PictureInPictureManager.shared.setup(sourceView: view, glContext: eaglContext, glkViewController: parsecGLK.glkViewController)
 			}

--- a/OpenParsec/ParsecViewController.swift
+++ b/OpenParsec/ParsecViewController.swift
@@ -195,7 +195,8 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate {
 		}
 
 		if #available(iOS 15.0, *) {
-			if let parsecGLK = glkView as? ParsecGLKViewController,
+			if SettingsHandler.enablePiP,
+			   let parsecGLK = glkView as? ParsecGLKViewController,
 			   let eaglContext = parsecGLK.eaglContext {
 				PictureInPictureManager.shared.setup(sourceView: view, glContext: eaglContext, glkViewController: parsecGLK.glkViewController)
 			}

--- a/OpenParsec/SceneDelegate.swift
+++ b/OpenParsec/SceneDelegate.swift
@@ -26,6 +26,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate
 		if #available(iOS 15.0, *) {
 			PictureInPictureManager.shared.stopPiP()
 		}
+		if ParsecBackgroundManager.shared.isPaused {
+			CParsec.resume()
+			ParsecBackgroundManager.shared.isPaused = false
+		}
 		ParsecBackgroundManager.shared.sceneDidBecomeActive()
 	}
 
@@ -50,7 +54,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate
 		}
 
 		if !pipAttempted && ParsecBackgroundManager.shared.hasActiveConnection {
-			ParsecBackgroundManager.shared.onShouldDisconnect?()
+			CParsec.sendReleaseMessage()
+			CParsec.pause()
+			ParsecBackgroundManager.shared.isPaused = true
 		}
 
 		ParsecBackgroundManager.shared.sceneDidEnterBackground()

--- a/OpenParsec/SceneDelegate.swift
+++ b/OpenParsec/SceneDelegate.swift
@@ -31,8 +31,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate
 			PictureInPictureManager.shared.stopPiP()
 		}
 		if ParsecBackgroundManager.shared.isPaused {
+			ParsecBackgroundManager.shared.glkViewController?.isPaused = false
 			CParsec.resume()
-			ParsecBackgroundManager.shared.isPaused = false
+			DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+				ParsecBackgroundManager.shared.isPaused = false
+			}
 		}
 		ParsecBackgroundManager.shared.sceneDidBecomeActive()
 	}
@@ -59,6 +62,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate
 		}
 
 		if !pipAttempted && ParsecBackgroundManager.shared.hasActiveConnection {
+			ParsecBackgroundManager.shared.glkViewController?.isPaused = true
 			CParsec.sendReleaseMessage()
 			CParsec.pause()
 			ParsecBackgroundManager.shared.isPaused = true

--- a/OpenParsec/SceneDelegate.swift
+++ b/OpenParsec/SceneDelegate.swift
@@ -19,6 +19,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate
 	}
 
 	func sceneDidDisconnect(_ scene: UIScene) {
+		if ParsecBackgroundManager.shared.hasActiveConnection {
+			CParsec.sendReleaseMessage()
+			CParsec.disconnect()
+		}
 	}
 
 	func sceneDidBecomeActive(_ scene: UIScene)
@@ -33,9 +37,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate
 		ParsecBackgroundManager.shared.sceneDidBecomeActive()
 	}
 
-	func sceneWillResignActive(_ scene: UIScene)
-	{
-		// Do NOT start PiP here — fires for app switcher gesture too. PiP starts in sceneDidEnterBackground.
+	func sceneWillResignActive(_ scene: UIScene) {
+		if ParsecBackgroundManager.shared.hasActiveConnection {
+			CParsec.sendReleaseMessage()
+		}
 		ParsecBackgroundManager.shared.sceneWillResignActive()
 	}
 

--- a/OpenParsec/SceneDelegate.swift
+++ b/OpenParsec/SceneDelegate.swift
@@ -47,7 +47,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate
 	{
 		var pipAttempted = false
 		if #available(iOS 15.0, *) {
-			if ParsecBackgroundManager.shared.hasActiveConnection {
+			if ParsecBackgroundManager.shared.hasActiveConnection && SettingsHandler.enablePiP {
 				PictureInPictureManager.shared.startPiP()
 				pipAttempted = PictureInPictureManager.shared.isPiPActive || PictureInPictureManager.shared.isStarting
 			}

--- a/OpenParsec/SceneDelegate.swift
+++ b/OpenParsec/SceneDelegate.swift
@@ -22,6 +22,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 		if #available(iOS 15.0, *) {
 			PictureInPictureManager.shared.stopPiP()
 		}
+		if ParsecBackgroundManager.shared.isPaused {
+			CParsec.resume()
+			ParsecBackgroundManager.shared.isPaused = false
+		}
 		ParsecBackgroundManager.shared.sceneDidBecomeActive()
 	}
 
@@ -43,7 +47,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 		}
 
 		if !pipAttempted && ParsecBackgroundManager.shared.hasActiveConnection {
-			ParsecBackgroundManager.shared.onShouldDisconnect?()
+			CParsec.sendReleaseMessage()
+			CParsec.pause()
+			ParsecBackgroundManager.shared.isPaused = true
 		}
 
 		ParsecBackgroundManager.shared.sceneDidEnterBackground()

--- a/OpenParsec/SceneDelegate.swift
+++ b/OpenParsec/SceneDelegate.swift
@@ -40,7 +40,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 	func sceneDidEnterBackground(_ scene: UIScene) {
 		var pipAttempted = false
 		if #available(iOS 15.0, *) {
-			if ParsecBackgroundManager.shared.hasActiveConnection {
+			if ParsecBackgroundManager.shared.hasActiveConnection && SettingsHandler.enablePiP {
 				PictureInPictureManager.shared.startPiP()
 				pipAttempted = PictureInPictureManager.shared.isPiPActive || PictureInPictureManager.shared.isStarting
 			}

--- a/OpenParsec/SceneDelegate.swift
+++ b/OpenParsec/SceneDelegate.swift
@@ -16,6 +16,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 	}
 
 	func sceneDidDisconnect(_ scene: UIScene) {
+		if ParsecBackgroundManager.shared.hasActiveConnection {
+			CParsec.sendReleaseMessage()
+			CParsec.disconnect()
+		}
 	}
 
 	func sceneDidBecomeActive(_ scene: UIScene) {
@@ -30,7 +34,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 	}
 
 	func sceneWillResignActive(_ scene: UIScene) {
-		// Do NOT start PiP here — fires for app switcher gesture too. PiP starts in sceneDidEnterBackground.
+		if ParsecBackgroundManager.shared.hasActiveConnection {
+			CParsec.sendReleaseMessage()
+		}
 		ParsecBackgroundManager.shared.sceneWillResignActive()
 	}
 

--- a/OpenParsec/SceneDelegate.swift
+++ b/OpenParsec/SceneDelegate.swift
@@ -27,8 +27,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 			PictureInPictureManager.shared.stopPiP()
 		}
 		if ParsecBackgroundManager.shared.isPaused {
+			ParsecBackgroundManager.shared.glkViewController?.isPaused = false
 			CParsec.resume()
-			ParsecBackgroundManager.shared.isPaused = false
+			DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+				ParsecBackgroundManager.shared.isPaused = false
+			}
 		}
 		ParsecBackgroundManager.shared.sceneDidBecomeActive()
 	}
@@ -53,6 +56,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 		}
 
 		if !pipAttempted && ParsecBackgroundManager.shared.hasActiveConnection {
+			ParsecBackgroundManager.shared.glkViewController?.isPaused = true
 			CParsec.sendReleaseMessage()
 			CParsec.pause()
 			ParsecBackgroundManager.shared.isPaused = true

--- a/OpenParsec/SettingsHandler.swift
+++ b/OpenParsec/SettingsHandler.swift
@@ -16,6 +16,7 @@ struct SettingsHandler {
 	@AppStorage("decoderCompatibility") public static var decoderCompatibility: Bool = false // Enable for stutter issues on some devices
 	@AppStorage("showKeyboardButton") public static var showKeyboardButton: Bool = true
 	@AppStorage("alwaysShowStatus") public static var alwaysShowStatus: Bool = false
+	@AppStorage("enablePiP") public static var enablePiP: Bool = true
 
 	@AppStorage("saveSessionSettings") public static var saveSessionSettings: Bool = true
 	@AppStorage("savedZoomEnabled") public static var savedZoomEnabled: Bool = false

--- a/OpenParsec/SettingsHandler.swift
+++ b/OpenParsec/SettingsHandler.swift
@@ -16,7 +16,7 @@ struct SettingsHandler {
 	@AppStorage("decoderCompatibility") public static var decoderCompatibility: Bool = false // Enable for stutter issues on some devices
 	@AppStorage("showKeyboardButton") public static var showKeyboardButton: Bool = true
 	@AppStorage("alwaysShowStatus") public static var alwaysShowStatus: Bool = false
-	@AppStorage("enablePiP") public static var enablePiP: Bool = true
+	@AppStorage("enablePiP") public static var enablePiP: Bool = false
 
 	@AppStorage("saveSessionSettings") public static var saveSessionSettings: Bool = true
 	@AppStorage("savedZoomEnabled") public static var savedZoomEnabled: Bool = false

--- a/OpenParsec/SettingsHandler.swift
+++ b/OpenParsec/SettingsHandler.swift
@@ -15,6 +15,7 @@ struct SettingsHandler {
 	@AppStorage("preferredFramesPerSecond") public static var preferredFramesPerSecond: Int = 60 // 0 = use device max (ProMotion)
 	@AppStorage("decoderCompatibility") public static var decoderCompatibility: Bool = false // Enable for stutter issues on some devices
 	@AppStorage("showKeyboardButton") public static var showKeyboardButton: Bool = true
+	@AppStorage("alwaysShowStatus") public static var alwaysShowStatus: Bool = false
 
 	@AppStorage("saveSessionSettings") public static var saveSessionSettings: Bool = true
 	@AppStorage("savedZoomEnabled") public static var savedZoomEnabled: Bool = false

--- a/OpenParsec/SettingsView.swift
+++ b/OpenParsec/SettingsView.swift
@@ -18,7 +18,8 @@ struct SettingsView:View
 	@AppStorage("decoderCompatibility") var decoderCompatibility: Bool = false // Enable for stutter issues on some devices
 	@AppStorage("showKeyboardButton") var showKeyboardButton: Bool = true
 	@AppStorage("saveSessionSettings") var saveSessionSettings: Bool = true
-	
+	@AppStorage("alwaysShowStatus") var alwaysShowStatus: Bool = false
+
 	let resolutionChoices: [Choice<ParsecResolution>]
 
 	init(visible: Binding<Bool>) {
@@ -169,10 +170,13 @@ struct SettingsView:View
 								Toggle("", isOn:$showKeyboardButton)
 									.frame(width:80)
 							}
-							CatItem("Save Session Settings")
-							{
-								Toggle("", isOn:$saveSessionSettings)
-									.frame(width:80)
+							CatItem("Always Show Status") {
+								Toggle("", isOn: $alwaysShowStatus)
+									.frame(width: 80)
+							}
+							CatItem("Save Session Settings") {
+								Toggle("", isOn: $saveSessionSettings)
+									.frame(width: 80)
 							}
 						}
 						Text(getVersionInfo())

--- a/OpenParsec/SettingsView.swift
+++ b/OpenParsec/SettingsView.swift
@@ -19,7 +19,7 @@ struct SettingsView:View
 	@AppStorage("showKeyboardButton") var showKeyboardButton: Bool = true
 	@AppStorage("saveSessionSettings") var saveSessionSettings: Bool = true
 	@AppStorage("alwaysShowStatus") var alwaysShowStatus: Bool = false
-	@AppStorage("enablePiP") var enablePiP: Bool = true
+	@AppStorage("enablePiP") var enablePiP: Bool = false
 
 	let resolutionChoices: [Choice<ParsecResolution>]
 

--- a/OpenParsec/SettingsView.swift
+++ b/OpenParsec/SettingsView.swift
@@ -19,6 +19,7 @@ struct SettingsView:View
 	@AppStorage("showKeyboardButton") var showKeyboardButton: Bool = true
 	@AppStorage("saveSessionSettings") var saveSessionSettings: Bool = true
 	@AppStorage("alwaysShowStatus") var alwaysShowStatus: Bool = false
+	@AppStorage("enablePiP") var enablePiP: Bool = true
 
 	let resolutionChoices: [Choice<ParsecResolution>]
 
@@ -172,6 +173,10 @@ struct SettingsView:View
 							}
 							CatItem("Always Show Status") {
 								Toggle("", isOn: $alwaysShowStatus)
+									.frame(width: 80)
+							}
+							CatItem("Picture in Picture") {
+								Toggle("", isOn: $enablePiP)
 									.frame(width: 80)
 							}
 							CatItem("Save Session Settings") {

--- a/OpenParsec/SettingsView.swift
+++ b/OpenParsec/SettingsView.swift
@@ -18,7 +18,7 @@ struct SettingsView: View {
 	@AppStorage("showKeyboardButton") var showKeyboardButton: Bool = true
 	@AppStorage("saveSessionSettings") var saveSessionSettings: Bool = true
 	@AppStorage("alwaysShowStatus") var alwaysShowStatus: Bool = false
-	@AppStorage("enablePiP") var enablePiP: Bool = true
+	@AppStorage("enablePiP") var enablePiP: Bool = false
 
 	let resolutionChoices: [Choice<ParsecResolution>]
 

--- a/OpenParsec/SettingsView.swift
+++ b/OpenParsec/SettingsView.swift
@@ -18,6 +18,7 @@ struct SettingsView: View {
 	@AppStorage("showKeyboardButton") var showKeyboardButton: Bool = true
 	@AppStorage("saveSessionSettings") var saveSessionSettings: Bool = true
 	@AppStorage("alwaysShowStatus") var alwaysShowStatus: Bool = false
+	@AppStorage("enablePiP") var enablePiP: Bool = true
 
 	let resolutionChoices: [Choice<ParsecResolution>]
 
@@ -147,6 +148,10 @@ struct SettingsView: View {
 							}
 							CatItem("Always Show Status") {
 								Toggle("", isOn: $alwaysShowStatus)
+									.frame(width: 80)
+							}
+							CatItem("Picture in Picture") {
+								Toggle("", isOn: $enablePiP)
 									.frame(width: 80)
 							}
 							CatItem("Save Session Settings") {

--- a/OpenParsec/SettingsView.swift
+++ b/OpenParsec/SettingsView.swift
@@ -17,6 +17,7 @@ struct SettingsView: View {
 	@AppStorage("decoderCompatibility") var decoderCompatibility: Bool = false // Enable for stutter issues on some devices
 	@AppStorage("showKeyboardButton") var showKeyboardButton: Bool = true
 	@AppStorage("saveSessionSettings") var saveSessionSettings: Bool = true
+	@AppStorage("alwaysShowStatus") var alwaysShowStatus: Bool = false
 
 	let resolutionChoices: [Choice<ParsecResolution>]
 
@@ -142,6 +143,10 @@ struct SettingsView: View {
 							}
 							CatItem("Show Keyboard Button") {
 								Toggle("", isOn: $showKeyboardButton)
+									.frame(width: 80)
+							}
+							CatItem("Always Show Status") {
+								Toggle("", isOn: $alwaysShowStatus)
 									.frame(width: 80)
 							}
 							CatItem("Save Session Settings") {


### PR DESCRIPTION
app kills the parsec connection when you switch apps or lock screen , this pr uses ParsecClientPause to pause and resume video/audio streams

some issues would appear where keys remain pressed even after disconnect, this pr would release all pressed keys on background so key presses doesn't get stuck on the host; gl render loop is also paused so it doesnt crash the app on sleep disconnects

pip controller is now only created when the setting is on (builds on #62), I added a toggle in settings for PiP, I also added toggles for status (top bar) and fixed mute to stop host audio streams instead of muting locally