### PR TITLE
Touchpad-style cursor control and crisp zoom

### DIFF
--- a/OpenParsec/ParsecGLKRenderer.swift
+++ b/OpenParsec/ParsecGLKRenderer.swift
@@ -6,6 +6,7 @@ class ParsecGLKRenderer: NSObject, GLKViewDelegate, GLKViewControllerDelegate {
 	var glkViewController: GLKViewController
 
 	var lastWidth: CGFloat = 1.0
+	var lastScale: CGFloat = 0
 
 	var lastImg: CGImage?
 	let updateImage: () -> Void
@@ -30,9 +31,10 @@ class ParsecGLKRenderer: NSObject, GLKViewDelegate, GLKViewControllerDelegate {
 
 	func glkView(_ view: GLKView, drawIn rect: CGRect) {
 		let deltaWidth: CGFloat = view.frame.size.width - lastWidth
-		if deltaWidth > 0.1 || deltaWidth < -0.1 {
-		    CParsec.setFrame(view.frame.size.width, view.frame.size.height, view.contentScaleFactor)
-	        lastWidth = view.frame.size.width
+		if deltaWidth > 0.1 || deltaWidth < -0.1 || abs(view.contentScaleFactor - lastScale) > 0.01 {
+			CParsec.setFrame(view.frame.size.width, view.frame.size.height, view.contentScaleFactor)
+			lastWidth = view.frame.size.width
+			lastScale = view.contentScaleFactor
 		}
 
 		// Calculate timeout based on configured/device frame rate

--- a/OpenParsec/ParsecViewController.swift
+++ b/OpenParsec/ParsecViewController.swift
@@ -19,8 +19,9 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate, ParsecTouchI
     var lastMouseX: Int32 = -1
     var lastMouseY: Int32 = -1
     var lastCursorHidden: Bool = false
-	var isPinching = false
 	var zoomEnabled = false
+	var appliedRenderScale: CGFloat = 0       // last contentScaleFactor applied (avoids redundant reallocations)
+	let maxRenderScale: CGFloat = 6.0         // cap on drawable density
 	var clickHoldActive = false        // left button held via long-press (file drag)
 	// Flick-to-glide momentum (tuned constants, not user settings).
 	var momentumLink: CADisplayLink?
@@ -40,6 +41,8 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate, ParsecTouchI
 	var cursorDidMoveThisTouch = false
 	var singleTouchStartScreen: CGPoint = .zero
 	let tapMoveSlop: CGFloat = 4.0          // finger movement (pts) above which a touch is a drag, not a tap
+	let staleTouchThreshold: TimeInterval = 1.5   // a touch idle this long vs an actively-moving one is a ghost
+	let staleMoveSlop: CGFloat = 24.0        // the moving finger must travel this far before a ghost is swept
 	var twoFingerDidMove = false            // true once a 2-finger gesture became a pinch/scroll (suppresses right-click)
 
 	var mouseSensitivity: Float = Float(SettingsHandler.mouseSensitivity)
@@ -54,6 +57,7 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate, ParsecTouchI
 	var isDragging = false
 	var twoFingerResidual = false       // leftover finger after a 2-finger gesture; inert until full lift
 	var activeTouches: [UITouch] = []   // ordered; first two drive pinch / scroll
+	var touchOrigins: [UITouch: CGPoint] = [:]   // begin location per touch, for ghost-sweep movement test
 
 	enum TwoFingerMode { case undecided, zoom, scroll }
 	var twoFingerMode: TwoFingerMode = .undecided
@@ -90,7 +94,31 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate, ParsecTouchI
 		fatalError("init(coder:) has not been implemented")
 	}
 
+	func computeRenderScale() -> CGFloat {
+		let nativeScale = UIScreen.main.nativeScale
+		guard scrollView.zoomScale > 1.01, let glk = glkView as? ParsecGLKViewController else { return nativeScale }
+		let vw = glk.glkView.frame.size.width
+		let vh = glk.glkView.frame.size.height
+		let sw = CGFloat(CParsec.hostWidth)
+		let sh = CGFloat(CParsec.hostHeight)
+		guard vw > 0, vh > 0, sw > 0, sh > 0 else { return nativeScale }
+		// Match the drawable to the source so zoom stays crisp without rendering wasted pixels.
+		let needed = max(sw / vw, sh / vh)
+		return min(maxRenderScale, max(nativeScale, needed))
+	}
+
+	func updateRenderScale() {
+		let target = computeRenderScale()
+		if abs(target - appliedRenderScale) > 0.01 {
+			appliedRenderScale = target
+			DispatchQueue.main.async { [weak self] in
+				(self?.glkView as? ParsecGLKViewController)?.glkView.contentScaleFactor = target
+			}
+		}
+	}
+
 	func updateImage() {
+		updateRenderScale()
         // Optimization: Snap current valus
         let currentMouseX = CParsec.mouseInfo.mouseX
         let currentMouseY = CParsec.mouseInfo.mouseY
@@ -212,20 +240,21 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate, ParsecTouchI
 		// All gestures (cursor, pinch-zoom, two-finger scroll) are handled in the
 		// ParsecTouchInputDelegate methods below, driven by touchOverlay's raw touches.
 
-		// Remove custom Pinch logic, ScrollView handles it.
-		// But we might want to know isPinching status?
-        // Let's rely on ScrollView delegate for updates.
-
 		// Add tap gesture recognizer for single-finger touch
 		let singleFingerTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleSingleFingerTap(_:)))
 		singleFingerTapGestureRecognizer.numberOfTouchesRequired = 1
 		singleFingerTapGestureRecognizer.allowedTouchTypes = [0, 2]
+		// Let the overlay see the real touch end so no phantom finger lingers.
+		singleFingerTapGestureRecognizer.cancelsTouchesInView = false
+		singleFingerTapGestureRecognizer.delaysTouchesEnded = false
 		view.addGestureRecognizer(singleFingerTapGestureRecognizer)
 
 		// Add tap gesture recognizer for two-finger touch
 		let twoFingerTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTwoFingerTap(_:)))
 		twoFingerTapGestureRecognizer.numberOfTouchesRequired = 2
 		twoFingerTapGestureRecognizer.allowedTouchTypes = [0]
+		twoFingerTapGestureRecognizer.cancelsTouchesInView = false
+		twoFingerTapGestureRecognizer.delaysTouchesEnded = false
 		view.addGestureRecognizer(twoFingerTapGestureRecognizer)
 		//		view.frame = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)
 		//		view.backgroundColor = UIColor(red: 0x66, green: 0xcc, blue: 0xff, alpha: 1.0)
@@ -233,6 +262,8 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate, ParsecTouchI
 		let threeFingerTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleThreeFinderTap(_:)))
 		threeFingerTapGestureRecognizer.numberOfTouchesRequired = 3
 		threeFingerTapGestureRecognizer.allowedTouchTypes = [0]
+		threeFingerTapGestureRecognizer.cancelsTouchesInView = false
+		threeFingerTapGestureRecognizer.delaysTouchesEnded = false
 		view.addGestureRecognizer(threeFingerTapGestureRecognizer)
 
 		let longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress(_:)))
@@ -253,6 +284,14 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate, ParsecTouchI
 			self,
 			selector: #selector(keyboardWillHide),
 			name: UIResponder.keyboardWillHideNotification,
+			object: nil
+		)
+
+		// Backgrounding / Control Center / system alerts can orphan touches; flush on resign.
+		NotificationCenter.default.addObserver(
+			self,
+			selector: #selector(appWillResignActive),
+			name: UIApplication.willResignActiveNotification,
 			object: nil
 		)
 
@@ -300,6 +339,7 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate, ParsecTouchI
 		}
 		NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
 		NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
+		NotificationCenter.default.removeObserver(self, name: UIApplication.willResignActiveNotification, object: nil)
 	}
 	
 	
@@ -465,9 +505,31 @@ extension ParsecViewController: UIGestureRecognizerDelegate {
 		let oldCount = activeTouches.count
 		// Rebuild from the event each time (keeping order) so a cancelled touch can't leave a stale one.
 		var ordered = activeTouches.filter { touches.contains($0) }
-		for t in touches where !ordered.contains(t) { ordered.append(t) }
+		for t in touches where !ordered.contains(t) {
+			ordered.append(t)
+			touchOrigins[t] = t.location(in: view)
+		}
+		// Sweep a ghost (an OS-dropped lift lingering as .stationary) only while another finger actively
+		// moves - a resting or just-tapped finger is never swept, so taps and held fingers stay safe.
+		var sweptGhost = false
+		if ordered.count >= 2 && !clickHoldActive,
+		   let newest = ordered.max(by: { $0.timestamp < $1.timestamp }) {
+			let origin = touchOrigins[newest] ?? newest.location(in: view)
+			let here = newest.location(in: view)
+			if hypot(here.x - origin.x, here.y - origin.y) > staleMoveSlop {
+				let fresh = ordered.filter { newest.timestamp - $0.timestamp < staleTouchThreshold }
+				if fresh.count < ordered.count { ordered = fresh; sweptGhost = true }
+			}
+		}
 		activeTouches = ordered
-		if activeTouches.count != oldCount {
+		touchOrigins = touchOrigins.filter { activeTouches.contains($0.key) }
+		if sweptGhost && activeTouches.count == 1 {
+			// Recover the surviving finger as a live cursor instead of inert two-finger residual.
+			stopMomentum()
+			twoFingerResidual = false
+			twoFingerMode = .undecided
+			startCursor()
+		} else if activeTouches.count != oldCount {
 			handleTouchCountChange(old: oldCount, new: activeTouches.count)
 		}
 		if moved { handleActiveTouchesMoved() }
@@ -507,6 +569,19 @@ extension ParsecViewController: UIGestureRecognizerDelegate {
 			CParsec.sendMouseClickMessage(ParsecMouseButton.init(rawValue: 1), false)
 			clickHoldActive = false
 		}
+	}
+
+	@objc private func appWillResignActive() { flushAllTouches() }
+
+	// Drop all touch state and release any held button so nothing sticks when backgrounded.
+	private func flushAllTouches() {
+		stopMomentum()
+		releaseClickHoldIfNeeded()
+		endCursorIfNeeded()
+		isDragging = false
+		twoFingerResidual = false
+		twoFingerMode = .undecided
+		activeTouches = []
 	}
 
 	private func startCursor() {
@@ -815,14 +890,7 @@ extension ParsecViewController: UIGestureRecognizerDelegate {
 		// Centering is handled on cursor movement (updateImage) and at the end of a pinch.
 	}
 
-	func scrollViewWillBeginZooming(_ scrollView: UIScrollView, with view: UIView?) {
-		// A pinch-to-zoom started: pause two-finger host scrolling until it ends so the
-		// same two-finger gesture isn't interpreted as both a zoom and a scroll.
-		isPinching = true
-	}
-
 	func scrollViewDidEndZooming(_ scrollView: UIScrollView, with view: UIView?, atScale scale: CGFloat) {
-		isPinching = false
 		centerViewportOnCursorPos()
 	}
 

--- a/OpenParsec/ParsecViewController.swift
+++ b/OpenParsec/ParsecViewController.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 import ParsecSDK
+import QuartzCore
 
 protocol ParsecPlayground {
 	init(viewController: UIViewController, updateImage: @escaping () -> Void)
@@ -9,7 +10,7 @@ protocol ParsecPlayground {
 	func updateSize(width: CGFloat, height: CGFloat)
 }
 
-class ParsecViewController: UIViewController, UIScrollViewDelegate {
+class ParsecViewController: UIViewController, UIScrollViewDelegate, ParsecTouchInputDelegate {
 	var glkView: ParsecPlayground!
 	var gamePadController: GamepadController!
 	var touchController: TouchController!
@@ -20,14 +21,46 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate {
     var lastCursorHidden: Bool = false
 	var isPinching = false
 	var zoomEnabled = false
-	var lastLongPressPoint: CGPoint = CGPoint()
-	var accumulatedDeltaX: Float = 0.0
-	var accumulatedDeltaY: Float = 0.0
-	var lastPanLocation: CGPoint = .zero
-	var lastPanTranslation: CGPoint = .zero
+	var clickHoldActive = false        // left button held via long-press (file drag)
+	// Flick-to-glide momentum (tuned constants, not user settings).
+	var momentumLink: CADisplayLink?
+	var cursorMomentumActive = false
+	var scrollMomentumActive = false
+	var cursorVelocity: CGPoint = .zero     // content points / sec
+	var scrollVelocity: Float = 0.0         // wheel units / sec
+	var lastCursorMoveTime: CFTimeInterval = 0
+	var lastScrollMoveTime: CFTimeInterval = 0
+	let flingMinSpeed: CGFloat = 80.0       // min release speed (content pts/sec) to start a cursor glide
+	let cursorStopSpeed: CGFloat = 40.0     // end the glide below this speed (lower = gentler, less abrupt)
+	let cursorDecayPerSec: Double = 0.08    // fraction of speed left after 1s (bigger = longer glide)
+	let scrollStartSpeed: Float = 800.0     // min release speed (wheel units/sec) to start a scroll glide
+	let scrollStopSpeed: Float = 200.0
+	let scrollDecayPerSec: Double = 0.004
+	// A left click fires only if the finger barely moved (else it's a cursor nudge).
+	var cursorDidMoveThisTouch = false
+	var singleTouchStartScreen: CGPoint = .zero
+	let tapMoveSlop: CGFloat = 4.0          // finger movement (pts) above which a touch is a drag, not a tap
+	var twoFingerDidMove = false            // true once a 2-finger gesture became a pinch/scroll (suppresses right-click)
 
 	var mouseSensitivity: Float = Float(SettingsHandler.mouseSensitivity)
-	var activatedPanFingerNumber: Int = 0
+	// Two-finger scroll-wheel accumulation, kept separate from cursor movement.
+	var lastScrollTranslation: CGPoint = .zero
+	var accumulatedScrollY: Float = 0.0
+	var scrollWheelSpeed: Float { Float(SettingsHandler.scrollSensitivity) * 2.3 }
+
+	// Input-driven cursor + viewport state (manual touch handling via TouchOverlayView).
+	var touchOverlay: TouchOverlayView!
+	var cursorContentPos: CGPoint = .zero
+	var isDragging = false
+	var twoFingerResidual = false       // leftover finger after a 2-finger gesture; inert until full lift
+	var activeTouches: [UITouch] = []   // ordered; first two drive pinch / scroll
+
+	enum TwoFingerMode { case undecided, zoom, scroll }
+	var twoFingerMode: TwoFingerMode = .undecided
+	var startPinchDistance: CGFloat = 0
+	var lastPinchDistance: CGFloat = 0
+	var startTwoFingerMidpoint: CGPoint = .zero
+	var lastTwoFingerMidpoint: CGPoint = .zero
 
 	var keyboardAccessoriesView: UIView?
 	var keyboardHeight: CGFloat = 0.0
@@ -82,79 +115,26 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate {
 				lastImg = currentImg!
 			}
 
-            // Using tracked values for bounds
-			u?.frame = CGRect(x: Int(currentMouseX) - Int(Double(CParsec.mouseInfo.cursorHotX) * SettingsHandler.cursorScale),
-							  y: Int(currentMouseY) - Int(Double(CParsec.mouseInfo.cursorHotY) * SettingsHandler.cursorScale),
-							  width: Int(Double(CParsec.mouseInfo.cursorWidth) * SettingsHandler.cursorScale),
-							  height: Int(Double(CParsec.mouseInfo.cursorHeight) * SettingsHandler.cursorScale))
-
-			// Check bounds and pan if needed
-			// Only pan if we are zoomed in OR if the keyboard is visible (to allow scrolling up)
-			if scrollView.zoomScale > 1.0 || (keyboardVisible && scrollView.contentInset.bottom > 0) {
-				let margin: CGFloat = 50.0
-
-                // Convert cursor frame to screen coordinates (relative to the ViewController's view)
-                // This accounts for zoom and current contentOffset automatically.
-                let cursorFrameInScreen = contentView.convert(u!.frame, to: view)
-                let viewBounds = view.bounds
-
-                var targetOffsetX = scrollView.contentOffset.x
-                var targetOffsetY = scrollView.contentOffset.y
-                var shouldScroll = false
-
-                // Check Left Edge
-                if cursorFrameInScreen.minX < margin {
-                    // We want the cursor to be at 'margin', so we shift contentOffset.
-                    // NewOffset = CurrentOffset - (Margin - CurrentPos)
-                    let diff = margin - cursorFrameInScreen.minX
-                    targetOffsetX -= diff
-                    shouldScroll = true
-                }
-
-                // Check Right Edge
-                if cursorFrameInScreen.maxX > viewBounds.width - margin {
-                    let diff = cursorFrameInScreen.maxX - (viewBounds.width - margin)
-                    targetOffsetX += diff
-                    shouldScroll = true
-                }
-
-                // Check Top Edge
-                if cursorFrameInScreen.minY < margin {
-                    let diff = margin - cursorFrameInScreen.minY
-                    targetOffsetY -= diff
-                    shouldScroll = true
-                }
-
-                // Check Bottom Edge
-                // If keyboard is visible, the "bottom" is the top of the keyboard.
-                let bottomInset = keyboardVisible ? keyboardHeight : 0.0
-                let effectiveViewHeight = viewBounds.height - bottomInset
-
-                if cursorFrameInScreen.maxY > effectiveViewHeight - margin {
-                    let diff = cursorFrameInScreen.maxY - (effectiveViewHeight - margin)
-                    targetOffsetY += diff
-                    shouldScroll = true
-                }
-
-                if shouldScroll {
-                    // Clamp to valid scroll range
-                    // Including contentInset.bottom in calculation to allow scrolling past the original content size
-                    let maxOffsetX = max(0, scrollView.contentSize.width - scrollView.bounds.width + scrollView.contentInset.right)
-                    let maxOffsetY = max(0, scrollView.contentSize.height - scrollView.bounds.height + scrollView.contentInset.bottom)
-
-                    targetOffsetX = max(-scrollView.contentInset.left, min(targetOffsetX, maxOffsetX))
-                    targetOffsetY = max(-scrollView.contentInset.top, min(targetOffsetY, maxOffsetY))
-
-                    // Use a slightly smoother animation or immediate update? 
-                    // 'updateImage' might be called frequently. animated: true might stack animations.
-                    // For direct control, 'animated: false' is often snappier and prevents lag, 
-                    // but 'true' is smoother visually. User asked for "image moves as mouse moves".
-                    // Given high frequency, false is safer, or manual interpolation.
-                    // Actually, standard UIScrollView behavior is usually direct setContentOffset.
-                    scrollView.setContentOffset(CGPoint(x: targetOffsetX, y: targetOffsetY), animated: false)
-                }
+			// While dragging, the touch handler owns the cursor position and viewport (smooth,
+			// input-driven). When idle, follow the host's reported cursor so host- or keyboard-
+			// driven moves are reflected and any prediction drift is corrected.
+			if !isDragging && !clickHoldActive && !cursorMomentumActive {
+				cursorContentPos = CGPoint(x: CGFloat(currentMouseX), y: CGFloat(currentMouseY))
+				positionCursorOverlay()
+				if scrollView.zoomScale > 1.0 {
+					centerViewportOnCursorPos()
+				} else if keyboardVisible && scrollView.contentInset.bottom > 0 {
+					// Not zoomed: keep the cursor above the on-screen keyboard.
+					let margin: CGFloat = 50.0
+					let effectiveViewHeight = view.bounds.height - keyboardHeight
+					if u!.frame.maxY > effectiveViewHeight - margin {
+						let diff = u!.frame.maxY - (effectiveViewHeight - margin)
+						let maxOffsetY = max(0, scrollView.contentSize.height - scrollView.bounds.height + scrollView.contentInset.bottom)
+						let targetOffsetY = min(scrollView.contentOffset.y + diff, maxOffsetY)
+						scrollView.setContentOffset(CGPoint(x: scrollView.contentOffset.x, y: targetOffsetY), animated: false)
+					}
+				}
 			}
-
 		} else {
 			u?.image = nil
 		}
@@ -167,13 +147,13 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate {
 		scrollView.minimumZoomScale = 1.0
 		scrollView.maximumZoomScale = 5.0
 		scrollView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-		scrollView.panGestureRecognizer.minimumNumberOfTouches = 2
-        /*
-         We set minimumNumberOfTouches to 2 for the scroll view's pan gesture
-         so that 1-finger drags are passed through to our custom gesture recognizers
-         (for moving the mouse).
-         Standard 2-finger pan will scroll the view.
-         */
+		// The scroll view is a programmatically-driven zoom/pan container only. Every touch is
+		// owned by touchOverlay (created below); the scroll view's own gestures are disabled so
+		// they can never race with or swallow our cursor / pinch / scroll handling.
+		scrollView.panGestureRecognizer.isEnabled = false
+		scrollView.pinchGestureRecognizer?.isEnabled = false
+		scrollView.isScrollEnabled = false
+		scrollView.bouncesZoom = false
 		view.addSubview(scrollView)
 
         // ContentView
@@ -204,8 +184,22 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate {
 		touchController.viewDidLoad()
 		gamePadController.viewDidLoad()
 
+		// Touch overlay: a transparent sibling ON TOP of the scroll view (and above the gamepad /
+		// touch controllers) that captures every raw touch and routes it deterministically
+		// (1 finger = cursor, 2 fingers = pinch / scroll). Added before the cursor image and the
+		// keyboard toolbar so those stay on top of it.
+		touchOverlay = TouchOverlayView(frame: view.bounds)
+		touchOverlay.backgroundColor = .clear
+		touchOverlay.isMultipleTouchEnabled = true
+		touchOverlay.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+		touchOverlay.inputDelegate = self
+		view.addSubview(touchOverlay)
+
+		// Cursor is a screen-space overlay ON TOP of everything (not inside the scroll view), so the
+		// zoom transform never scales it - keeping it crisp and a constant on-screen size.
 		u = UIImageView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-		contentView.addSubview(u!) // Add Cursor to ContentView
+		u!.isUserInteractionEnabled = false
+		view.addSubview(u!)
 
 		setNeedsUpdateOfPrefersPointerLocked()
 
@@ -215,12 +209,8 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate {
 		view.isMultipleTouchEnabled = true
 		view.isUserInteractionEnabled = true
 
-		let panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(self.handlePanGesture(_:)))
-		panGestureRecognizer.delegate = self
-		// Important: Allow our pan gesture to work alongside scrollview's?
-		// No, we want 1 finger for this pan, 2 fingers for scrollview.
-		// So they are distinct by touch count.
-		view.addGestureRecognizer(panGestureRecognizer)
+		// All gestures (cursor, pinch-zoom, two-finger scroll) are handled in the
+		// ParsecTouchInputDelegate methods below, driven by touchOverlay's raw touches.
 
 		// Remove custom Pinch logic, ScrollView handles it.
 		// But we might want to know isPinching status?
@@ -248,6 +238,8 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate {
 		let longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress(_:)))
 		longPressGestureRecognizer.numberOfTouchesRequired = 1
 		longPressGestureRecognizer.allowedTouchTypes = [0, 2]
+		// Don't cancel the overlay's touch, so the click-hold button can be released on lift.
+		longPressGestureRecognizer.cancelsTouchesInView = false
 		view.addGestureRecognizer(longPressGestureRecognizer)
 
 		NotificationCenter.default.addObserver(
@@ -296,11 +288,12 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate {
 		if keyboardVisible {
 			becomeFirstResponder()
 		}
-		scrollView.pinchGestureRecognizer?.isEnabled = zoomEnabled
+		// (Pinch-to-zoom is driven manually via touchOverlay; the scroll view's pinch stays off.)
 	}
 
 	override func viewWillDisappear(_ animated: Bool) {
 		super.viewWillDisappear(animated)
+		stopMomentum()
 		if let parent = parent {
 			parent.setChildForHomeIndicatorAutoHidden(nil)
 			parent.setChildViewControllerForPointerLock(nil)
@@ -463,98 +456,322 @@ extension ParsecViewController: UIGestureRecognizerDelegate {
 		// Pinch is handled by UIScrollView
 	}
 
-	@objc func handlePanGesture(_ gestureRecognizer: UIPanGestureRecognizer) {
-		//		print("number = \(gestureRecognizer.numberOfTouches) status = \(gestureRecognizer.state.rawValue)")
-		// lock activatedPanFingerNumber in case user not releasing both finger at the same time
-		if gestureRecognizer.numberOfTouches == 0 {
-			if gestureRecognizer.state == .ended || gestureRecognizer.state == .cancelled {
-				activatedPanFingerNumber = 0
-				// Reset accumulators
-				accumulatedDeltaX = 0.0
-				accumulatedDeltaY = 0.0
-				lastPanTranslation = .zero
+	// MARK: - Manual touch handling (ParsecTouchInputDelegate)
+	// touchOverlay delivers raw touches here. One finger drives the mouse cursor; two fingers are
+	// classified once per gesture into either pinch-zoom or host scroll-wheel (never both), so the
+	// gestures never fight. No UIScrollView gesture recognizer is in the loop.
 
-				if SettingsHandler.cursorMode == .direct {
-					let button = ParsecMouseButton.init(rawValue: 1)
-					CParsec.sendMouseClickMessage(button, false)
-				}
+	func parsecTouchesUpdated(_ touches: Set<UITouch>, moved: Bool) {
+		let oldCount = activeTouches.count
+		// Rebuild from the event each time (keeping order) so a cancelled touch can't leave a stale one.
+		var ordered = activeTouches.filter { touches.contains($0) }
+		for t in touches where !ordered.contains(t) { ordered.append(t) }
+		activeTouches = ordered
+		if activeTouches.count != oldCount {
+			handleTouchCountChange(old: oldCount, new: activeTouches.count)
+		}
+		if moved { handleActiveTouchesMoved() }
+	}
+
+	private func handleTouchCountChange(old: Int, new: Int) {
+		if new > old { stopMomentum() }   // any new finger cancels an in-progress glide
+		if new == 0 {
+			let flingCursor = (old == 1) && isDragging && !twoFingerResidual && !clickHoldActive
+			let flingScroll = (old >= 2) && (twoFingerMode == .scroll)
+			releaseClickHoldIfNeeded()   // defensive: the left button must never stay stuck down
+			endCursorIfNeeded()
+			isDragging = false
+			twoFingerResidual = false
+			twoFingerMode = .undecided
+			if flingCursor { startCursorMomentum() }
+			if flingScroll { startScrollMomentum() }
+		} else if new == 1 {
+			if old >= 2 {
+				// Leftover finger after a two-finger gesture: stay inert until full lift so it
+				// doesn't jump the cursor.
+				if twoFingerMode == .scroll { startScrollMomentum() }
+				twoFingerResidual = true
+				twoFingerMode = .undecided
+			} else if old == 0 {
+				startCursor()
 			}
-		} else if activatedPanFingerNumber == 2 || (gestureRecognizer.numberOfTouches == 2 && activatedPanFingerNumber == 0) {
-            // Native UIScrollView handles 2-finger pan for scrolling.
-            // We disable the mouse wheel for now to avoid conflict, or we can check gesture state.
-            // If user wants wheel, we might need a specific mode or 3 fingers.
-			if zoomEnabled {
-				return
-			}
-			activatedPanFingerNumber = 2
-			let velocity = gestureRecognizer.velocity(in: gestureRecognizer.view)
-
-			if abs(velocity.y) > 2 {
-				// Run your function when the user uses two fingers and swipes upwards
-				CParsec.sendWheelMsg(x: 0, y: Int32(Float(velocity.y) / 20 * mouseSensitivity))
-				return
-			}
-			if SettingsHandler.cursorMode == .direct {
-				let location = gestureRecognizer.location(in: gestureRecognizer.view)
-				touchController.onTouch(typeOfTap: 1, location: location, state: gestureRecognizer.state)
-			}
-		} else if activatedPanFingerNumber == 1 || (gestureRecognizer.numberOfTouches == 1 && activatedPanFingerNumber == 0) {
-			activatedPanFingerNumber = 1
-			// move mouse
-			if SettingsHandler.cursorMode == .direct {
-                // Map screen tap to content coordinates
-				let position = gestureRecognizer.location(in: gestureRecognizer.view)
-                // Convert to content coordinates
-				let adjustedPosition = contentView.convert(position, from: view)
-				CParsec.sendMousePosition(Int32(adjustedPosition.x), Int32(adjustedPosition.y))
-			} else {
-				// Simple translation-based movement with sub-pixel accumulation
-				let currentTranslation = gestureRecognizer.translation(in: gestureRecognizer.view)
-
-				if gestureRecognizer.state == .began {
-					lastPanTranslation = .zero
-					accumulatedDeltaX = 0.0
-					accumulatedDeltaY = 0.0
-				}
-
-				// Calculate delta since last update
-				let deltaX = Float(currentTranslation.x - lastPanTranslation.x) * mouseSensitivity
-				let deltaY = Float(currentTranslation.y - lastPanTranslation.y) * mouseSensitivity
-
-				lastPanTranslation = currentTranslation
-
-				// Accumulate for sub-pixel precision
-				accumulatedDeltaX += deltaX
-				accumulatedDeltaY += deltaY
-
-				// Send movement when we have at least 1 pixel
-				let intDeltaX = Int32(accumulatedDeltaX)
-				let intDeltaY = Int32(accumulatedDeltaY)
-
-				if intDeltaX != 0 || intDeltaY != 0 {
-					CParsec.sendMouseDelta(intDeltaX, intDeltaY)
-					accumulatedDeltaX -= Float(intDeltaX)
-					accumulatedDeltaY -= Float(intDeltaY)
-				}
-			}
-
-			if gestureRecognizer.state == .began && SettingsHandler.cursorMode == .direct {
-				let button = ParsecMouseButton.init(rawValue: 1)
-				CParsec.sendMouseClickMessage(button, true)
-			}
-
+		} else if new >= 2 {
+			releaseClickHoldIfNeeded()   // can't keep the button held during a two-finger gesture
+			if isDragging { endCursorIfNeeded(); isDragging = false }
+			beginTwoFinger()
 		}
 	}
 
-	@objc func handleSingleFingerTap(_ gestureRecognizer: UITapGestureRecognizer) {
+	private func releaseClickHoldIfNeeded() {
+		if clickHoldActive {
+			CParsec.sendMouseClickMessage(ParsecMouseButton.init(rawValue: 1), false)
+			clickHoldActive = false
+		}
+	}
 
+	private func startCursor() {
+		isDragging = true
+		twoFingerResidual = false
+		cursorDidMoveThisTouch = false
+		singleTouchStartScreen = activeTouches.first?.location(in: view) ?? .zero
+		if SettingsHandler.cursorMode == .direct {
+			CParsec.sendMouseClickMessage(ParsecMouseButton.init(rawValue: 1), true)
+		}
+	}
+
+	private func endCursorIfNeeded() {
+		if isDragging && SettingsHandler.cursorMode == .direct {
+			CParsec.sendMouseClickMessage(ParsecMouseButton.init(rawValue: 1), false)
+		}
+	}
+
+	private func beginTwoFinger() {
+		twoFingerMode = .undecided
+		twoFingerDidMove = false
+		accumulatedScrollY = 0.0
+		let d = twoFingerDistanceAndMidpoint()
+		startPinchDistance = d.distance
+		lastPinchDistance = d.distance
+		startTwoFingerMidpoint = d.midpoint
+		lastTwoFingerMidpoint = d.midpoint
+	}
+
+	private func twoFingerDistanceAndMidpoint() -> (distance: CGFloat, midpoint: CGPoint) {
+		let pts = activeTouches.prefix(2).map { $0.location(in: view) }
+		guard pts.count == 2 else { return (0, pts.first ?? .zero) }
+		let dx = pts[1].x - pts[0].x
+		let dy = pts[1].y - pts[0].y
+		let mid = CGPoint(x: (pts[0].x + pts[1].x) / 2, y: (pts[0].y + pts[1].y) / 2)
+		return (hypot(dx, dy), mid)
+	}
+
+	private func handleActiveTouchesMoved() {
+		if (isDragging || clickHoldActive), !twoFingerResidual, activeTouches.count == 1, let t = activeTouches.first {
+			moveCursor(with: t)
+		} else if activeTouches.count >= 2 {
+			handleTwoFinger()
+		}
+	}
+
+	private func moveCursor(with t: UITouch) {
+		let zoom = scrollView.zoomScale
+		let loc = t.location(in: view)
+		let prev = t.previousLocation(in: view)
+		if hypot(loc.x - singleTouchStartScreen.x, loc.y - singleTouchStartScreen.y) > tapMoveSlop {
+			cursorDidMoveThisTouch = true
+		}
+
+		if CParsec.mouseInfo.mousePositionRelative {
+			// Host has captured the pointer (e.g. a game): send true relative motion instead.
+			let s = CGFloat(mouseSensitivity) / zoom
+			CParsec.sendMouseDelta(Int32((loc.x - prev.x) * s), Int32((loc.y - prev.y) * s))
+			return
+		}
+
+		if SettingsHandler.cursorMode == .direct {
+			cursorContentPos = clampToContent(contentView.convert(loc, from: view))
+		} else {
+			// Relative finger movement, predicted locally; sensitivity scales down with zoom so the
+			// cursor tracks the visible finger.
+			let s = CGFloat(mouseSensitivity) / zoom
+			let dcx = (loc.x - prev.x) * s
+			let dcy = (loc.y - prev.y) * s
+			cursorContentPos = clampToContent(CGPoint(x: cursorContentPos.x + dcx, y: cursorContentPos.y + dcy))
+			// Smoothed velocity so a quick flick keeps gliding after the finger lifts.
+			let now = CACurrentMediaTime()
+			let dt = CGFloat(now - lastCursorMoveTime)
+			if dt > 0.0005 && dt < 0.1 {
+				cursorVelocity = CGPoint(x: cursorVelocity.x * 0.4 + (dcx / dt) * 0.6,
+										 y: cursorVelocity.y * 0.4 + (dcy / dt) * 0.6)
+			}
+			lastCursorMoveTime = now
+		}
+		// Command the host to the ABSOLUTE predicted position (not a delta) so the host cursor can't
+		// crawl behind network round-trips - clicks always land where the cursor is drawn.
+		CParsec.sendMousePosition(Int32(cursorContentPos.x), Int32(cursorContentPos.y))
+		centerViewportOnCursorPos()
+		positionCursorOverlay()
+	}
+
+	private func handleTwoFinger() {
+		let d = twoFingerDistanceAndMidpoint()
+		if twoFingerMode == .undecided {
+			let distDelta = abs(d.distance - startPinchDistance)
+			let midDelta = hypot(d.midpoint.x - startTwoFingerMidpoint.x, d.midpoint.y - startTwoFingerMidpoint.y)
+			let deadZone: CGFloat = 12.0
+			if distDelta > deadZone || midDelta > deadZone {
+				twoFingerMode = (distDelta > midDelta && zoomEnabled) ? .zoom : .scroll
+				twoFingerDidMove = true
+			}
+		}
+		switch twoFingerMode {
+		case .zoom:
+			if lastPinchDistance > 0 {
+				applyZoom(to: scrollView.zoomScale * (d.distance / lastPinchDistance), anchorInView: d.midpoint)
+			}
+		case .scroll:
+			let deltaY = Float(d.midpoint.y - lastTwoFingerMidpoint.y)
+			let direction: Float = SettingsHandler.reverseScrollDirection ? -1.0 : 1.0
+			let contribution = deltaY * scrollWheelSpeed * direction
+			accumulatedScrollY += contribution
+			let intScrollY = Int32(accumulatedScrollY)
+			if intScrollY != 0 {
+				CParsec.sendWheelMsg(x: 0, y: intScrollY)
+				accumulatedScrollY -= Float(intScrollY)
+			}
+			// Track scroll velocity for a little post-flick momentum.
+			let snow = CACurrentMediaTime()
+			let sdt = Float(snow - lastScrollMoveTime)
+			if sdt > 0.0005 && sdt < 0.1 {
+				scrollVelocity = scrollVelocity * 0.4 + (contribution / sdt) * 0.6
+			}
+			lastScrollMoveTime = snow
+		case .undecided:
+			break
+		}
+		lastPinchDistance = d.distance
+		lastTwoFingerMidpoint = d.midpoint
+	}
+
+	private func startCursorMomentum() {
+		guard SettingsHandler.cursorMode == .touchpad, !CParsec.mouseInfo.mousePositionRelative else { return }
+		guard CACurrentMediaTime() - lastCursorMoveTime < 0.06 else { return }   // finger was still moving at release
+		guard hypot(cursorVelocity.x, cursorVelocity.y) > flingMinSpeed else { return }
+		// Less glide when zoomed out: at 1x the cursor crosses the screen instead of panning the view.
+		let glideScale = min(1.0, 0.3 + 0.7 * (scrollView.zoomScale - 1.0))
+		cursorVelocity.x *= glideScale
+		cursorVelocity.y *= glideScale
+		cursorMomentumActive = true
+		ensureMomentumLink()
+	}
+
+	private func startScrollMomentum() {
+		guard CACurrentMediaTime() - lastScrollMoveTime < 0.06 else { return }
+		guard abs(scrollVelocity) > scrollStartSpeed else { return }
+		scrollMomentumActive = true
+		ensureMomentumLink()
+	}
+
+	private func ensureMomentumLink() {
+		if momentumLink == nil {
+			let link = CADisplayLink(target: self, selector: #selector(momentumTick(_:)))
+			link.add(to: .main, forMode: .common)
+			momentumLink = link
+		}
+	}
+
+	func stopMomentum() {
+		cursorMomentumActive = false
+		scrollMomentumActive = false
+		cursorVelocity = .zero
+		scrollVelocity = 0
+		momentumLink?.invalidate()
+		momentumLink = nil
+	}
+
+	@objc func momentumTick(_ link: CADisplayLink) {
+		let dt = CGFloat(link.targetTimestamp - link.timestamp)
+		if dt <= 0 { return }
+		var stillActive = false
+
+		if cursorMomentumActive {
+			let decay = CGFloat(pow(cursorDecayPerSec, Double(dt)))
+			cursorVelocity.x *= decay
+			cursorVelocity.y *= decay
+			let before = cursorContentPos
+			cursorContentPos = clampToContent(CGPoint(x: cursorContentPos.x + cursorVelocity.x * dt,
+													  y: cursorContentPos.y + cursorVelocity.y * dt))
+			if !CParsec.mouseInfo.mousePositionRelative {
+				CParsec.sendMousePosition(Int32(cursorContentPos.x), Int32(cursorContentPos.y))
+			}
+			centerViewportOnCursorPos()
+			positionCursorOverlay()
+			let stalled = abs(cursorContentPos.x - before.x) < 0.05 && abs(cursorContentPos.y - before.y) < 0.05
+			if hypot(cursorVelocity.x, cursorVelocity.y) < cursorStopSpeed || stalled {
+				cursorMomentumActive = false
+			} else {
+				stillActive = true
+			}
+		}
+
+		if scrollMomentumActive {
+			scrollVelocity *= Float(pow(scrollDecayPerSec, Double(dt)))
+			accumulatedScrollY += scrollVelocity * Float(dt)
+			let i = Int32(accumulatedScrollY)
+			if i != 0 {
+				CParsec.sendWheelMsg(x: 0, y: i)
+				accumulatedScrollY -= Float(i)
+			}
+			if abs(scrollVelocity) < scrollStopSpeed {
+				scrollMomentumActive = false
+			} else {
+				stillActive = true
+			}
+		}
+
+		if !stillActive { stopMomentum() }
+	}
+
+	// Manually zoom the scroll view around a screen-space anchor (the pinch midpoint), keeping the
+	// content point under the anchor fixed. Replaces the scroll view's own pinch recognizer.
+	private func applyZoom(to targetScale: CGFloat, anchorInView anchor: CGPoint) {
+		let oldZoom = scrollView.zoomScale
+		let newZoom = min(max(targetScale, scrollView.minimumZoomScale), scrollView.maximumZoomScale)
+		guard abs(newZoom - oldZoom) > 0.0001 else { return }
+		let off = scrollView.contentOffset
+		let contentX = (anchor.x + off.x) / oldZoom
+		let contentY = (anchor.y + off.y) / oldZoom
+		scrollView.zoomScale = newZoom
+		var newOff = CGPoint(x: contentX * newZoom - anchor.x, y: contentY * newZoom - anchor.y)
+		let maxX = max(0, scrollView.contentSize.width - scrollView.bounds.width)
+		let maxY = max(0, scrollView.contentSize.height - scrollView.bounds.height)
+		newOff.x = min(max(0, newOff.x), maxX)
+		newOff.y = min(max(0, newOff.y), maxY)
+		scrollView.setContentOffset(newOff, animated: false)
+		// Park the cursor at the viewport centre after zooming so a later drag doesn't snap the view.
+		let bottomInset = keyboardVisible ? keyboardHeight : 0.0
+		let centerX = (scrollView.bounds.width / 2 + scrollView.contentOffset.x) / newZoom
+		let centerY = ((scrollView.bounds.height - bottomInset) / 2 + scrollView.contentOffset.y) / newZoom
+		cursorContentPos = clampToContent(CGPoint(x: centerX, y: centerY))
+		if !CParsec.mouseInfo.mousePositionRelative {
+			CParsec.sendMousePosition(Int32(cursorContentPos.x), Int32(cursorContentPos.y))
+		}
+		positionCursorOverlay()
+	}
+
+	private func clampToContent(_ p: CGPoint) -> CGPoint {
+		let w = view.bounds.width
+		let h = view.bounds.height
+		return CGPoint(x: min(max(0, p.x), w), y: min(max(0, p.y), h))
+	}
+
+	// Places the cursor overlay at the cursor's content position projected into screen space,
+	// drawn at full Cursor Scale (no zoom division) so it stays crisp and constant-sized.
+	func positionCursorOverlay() {
+		guard let u = u else { return }
+		let zoom = scrollView.zoomScale
+		let off = scrollView.contentOffset
+		let screenX = cursorContentPos.x * zoom - off.x
+		let screenY = cursorContentPos.y * zoom - off.y
+		let cs = CGFloat(SettingsHandler.cursorScale)
+		let hotX = CGFloat(CParsec.mouseInfo.cursorHotX) * cs
+		let hotY = CGFloat(CParsec.mouseInfo.cursorHotY) * cs
+		let w = CGFloat(CParsec.mouseInfo.cursorWidth) * cs
+		let h = CGFloat(CParsec.mouseInfo.cursorHeight) * cs
+		u.frame = CGRect(x: screenX - hotX, y: screenY - hotY, width: w, height: h)
+	}
+
+	@objc func handleSingleFingerTap(_ gestureRecognizer: UITapGestureRecognizer) {
+		// Only click if the finger stayed put; a moved finger was a cursor nudge, not a tap.
+		if cursorDidMoveThisTouch { return }
 		let location = gestureRecognizer.location(in: gestureRecognizer.view)
 		let adjustedLocation = contentView.convert(location, from: view)
 		touchController.onTap(typeOfTap: 1, location: adjustedLocation)
 	}
 
 	@objc func handleTwoFingerTap(_ gestureRecognizer: UITapGestureRecognizer) {
-
+		// A two-finger TAP is a right click; if the fingers moved (pinch/scroll) it wasn't a tap.
+		if twoFingerDidMove { return }
 		let location: CGPoint
 		switch SettingsHandler.rightClickPosition {
 		case .firstFinger:
@@ -577,22 +794,15 @@ extension ParsecViewController: UIGestureRecognizerDelegate {
 		if SettingsHandler.cursorMode != .touchpad {
 			return
 		}
-		let button = ParsecMouseButton.init(rawValue: 1)
-
-		if gestureRecognizer.state == .began {
-			CParsec.sendMouseClickMessage(button, true)
-			let location = gestureRecognizer.location(in: gestureRecognizer.view)
-			lastLongPressPoint = contentView.convert(location, from: view)
-		} else if gestureRecognizer.state == .ended {
-			CParsec.sendMouseClickMessage(button, false)
-		} else if gestureRecognizer.state == .changed {
-			let newLocation = gestureRecognizer.location(in: gestureRecognizer.view)
-            let adjustedNewLocation = contentView.convert(newLocation, from: view)
-			CParsec.sendMouseDelta(
-				Int32(Float(adjustedNewLocation.x - lastLongPressPoint.x) * mouseSensitivity),
-				Int32(Float(adjustedNewLocation.y - lastLongPressPoint.y) * mouseSensitivity)
-			)
-			lastLongPressPoint = adjustedNewLocation
+		switch gestureRecognizer.state {
+		case .began:
+			// Click-and-hold (file drag): hold the left button; the overlay keeps moving the cursor.
+			clickHoldActive = true
+			CParsec.sendMouseClickMessage(ParsecMouseButton.init(rawValue: 1), true)
+		case .ended, .cancelled, .failed:
+			releaseClickHoldIfNeeded()
+		default:
+			break
 		}
 	}
 
@@ -602,12 +812,42 @@ extension ParsecViewController: UIGestureRecognizerDelegate {
 	}
 
 	func scrollViewDidZoom(_ scrollView: UIScrollView) {
-		// Update isPinching if needed, or other logic
+		// Centering is handled on cursor movement (updateImage) and at the end of a pinch.
+	}
+
+	func scrollViewWillBeginZooming(_ scrollView: UIScrollView, with view: UIView?) {
+		// A pinch-to-zoom started: pause two-finger host scrolling until it ends so the
+		// same two-finger gesture isn't interpreted as both a zoom and a scroll.
+		isPinching = true
+	}
+
+	func scrollViewDidEndZooming(_ scrollView: UIScrollView, with view: UIView?, atScale scale: CGFloat) {
+		isPinching = false
+		centerViewportOnCursorPos()
+	}
+
+	// Slides the viewport so the host cursor stays centered on screen while zoomed in,
+	// clamped so the cursor can still reach the true edges of the host screen.
+	func centerViewportOnCursorPos() {
+		guard scrollView.zoomScale > 1.0 else { return }
+		let zoom = scrollView.zoomScale
+		let bottomInset = keyboardVisible ? keyboardHeight : 0.0
+		let visibleWidth = view.bounds.width
+		let visibleHeight = view.bounds.height - bottomInset
+		let cursorX = cursorContentPos.x * zoom
+		let cursorY = cursorContentPos.y * zoom
+		var targetX = cursorX - visibleWidth / 2
+		var targetY = cursorY - visibleHeight / 2
+		let maxX = max(0, scrollView.contentSize.width - scrollView.bounds.width)
+		let maxY = max(0, scrollView.contentSize.height - scrollView.bounds.height + bottomInset)
+		targetX = min(max(0, targetX), maxX)
+		targetY = min(max(0, targetY), maxY)
+		scrollView.setContentOffset(CGPoint(x: targetX, y: targetY), animated: false)
 	}
 
 	func setZoomEnabled(_ enabled: Bool) {
+		// Pinch is driven manually in touchOverlay; just gate it with this flag.
 		zoomEnabled = enabled
-		scrollView.pinchGestureRecognizer?.isEnabled = enabled
 	}
 
 }
@@ -852,4 +1092,26 @@ extension ParsecViewController: UIKeyInput, UITextInputTraits {
 		}
 	}
 
+}
+
+protocol ParsecTouchInputDelegate: AnyObject {
+	// Called on every touch change with the authoritative set of currently-active touches.
+	func parsecTouchesUpdated(_ activeTouches: Set<UITouch>, moved: Bool)
+}
+
+// A transparent overlay that owns every raw touch and forwards it to the controller. Sitting on
+// top of (not inside) the scroll view, it gives deterministic, unfiltered touch delivery with no
+// UIScrollView gesture races - the controller decides 1-finger cursor vs 2-finger pinch / scroll.
+class TouchOverlayView: UIView {
+	weak var inputDelegate: ParsecTouchInputDelegate?
+
+	// Forward the live touch set (excluding ended/cancelled) on every event.
+	private func forward(_ event: UIEvent?, moved: Bool) {
+		let active = (event?.allTouches ?? []).filter { $0.phase != .ended && $0.phase != .cancelled }
+		inputDelegate?.parsecTouchesUpdated(active, moved: moved)
+	}
+	override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) { forward(event, moved: false) }
+	override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) { forward(event, moved: true) }
+	override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) { forward(event, moved: false) }
+	override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) { forward(event, moved: false) }
 }

--- a/OpenParsec/SettingsHandler.swift
+++ b/OpenParsec/SettingsHandler.swift
@@ -12,6 +12,8 @@ struct SettingsHandler {
 	@AppStorage("noOverlay") public static var noOverlay: Bool = false
 	@AppStorage("hideStatusBar") public static var hideStatusBar: Bool = true
 	@AppStorage("rightClickPosition") public static var rightClickPosition: RightClickPosition = .firstFinger
+	@AppStorage("reverseScrollDirection") public static var reverseScrollDirection: Bool = false
+	@AppStorage("scrollSensitivity") public static var scrollSensitivity: Double = 1.5
 	@AppStorage("preferredFramesPerSecond") public static var preferredFramesPerSecond: Int = 60 // 0 = use device max (ProMotion)
 	@AppStorage("decoderCompatibility") public static var decoderCompatibility: Bool = false // Enable for stutter issues on some devices
 	@AppStorage("showKeyboardButton") public static var showKeyboardButton: Bool = true

--- a/OpenParsec/SettingsView.swift
+++ b/OpenParsec/SettingsView.swift
@@ -13,6 +13,8 @@ struct SettingsView: View {
 	@AppStorage("noOverlay") var noOverlay: Bool = false
 	@AppStorage("hideStatusBar") var hideStatusBar: Bool = true
 	@AppStorage("rightClickPosition") var rightClickPosition: RightClickPosition = .firstFinger
+	@AppStorage("reverseScrollDirection") var reverseScrollDirection: Bool = false
+	@AppStorage("scrollSensitivity") var scrollSensitivity: Double = 1.5
 	@AppStorage("preferredFramesPerSecond") var preferredFramesPerSecond: Int = 60 // 0 = use device max (ProMotion)
 	@AppStorage("decoderCompatibility") var decoderCompatibility: Bool = false // Enable for stutter issues on some devices
 	@AppStorage("showKeyboardButton") var showKeyboardButton: Bool = true
@@ -83,6 +85,15 @@ struct SettingsView: View {
 									Choice("Middle", RightClickPosition.middle),
 									Choice("Second Finger", RightClickPosition.secondFinger)
 								])
+							}
+							CatItem("Scroll Speed") {
+								Slider(value: $scrollSensitivity, in: 0.5...5, step: 0.5)
+									.frame(width: 200)
+								Text(String(format: "%.1f", scrollSensitivity))
+							}
+							CatItem("Reverse Scroll Direction") {
+								Toggle("", isOn: $reverseScrollDirection)
+									.frame(width: 80)
 							}
                             CatItem("Cursor Scale") {
                                 Slider(value: $cursorScale, in: 0.1...4, step: 0.1)


### PR DESCRIPTION
Love the app, been using it more it to remotely control my Macs and PCs. Two related touch/zoom improvements here, in separate commits so they're easy to review or take independently. I've used many VNC/RDP iPhone apps over the years and think these are crucial enhancements to make OpenParsec much better at remote desktop control on touchscreen.

**Centered-cursor touch control**. Reworks touch input into a touchpad-style model: cursor stays centered and you move it by dragging, with two-finger pinch-zoom and scroll, long-press for click-and-drag, and a little flick-to-glide momentum. IMO, this is a much more fluid and responsive touch experience.

**Crisp zoom**. When you zoom in, the GL drawable density is raised to match the host's source resolution so the magnified image stays sharp instead of blurring. It's gated on actual zoom, so there's no extra GPU cost at 1×. 

**QoL Fixes**. A few robust fixes from on-device testing: tap recognizers no longer swallow touch-end events (which could occasionally strand a phantom finger and stick the view in zoom or scroll), touch state is flushed if the app gets backgrounded mid-gesture, and a stale "ghost" touch left by a dropped OS touch-end is swept once another finger is clearly moving. Both mouse clicks and movements are now much more reliable. 
Also added new settings in Interactivity: Scroll Speed and Reverse Scroll Direction.

No new dependencies, all on the existing GLKit render path. Tested on iPhone Air, iOS 27 DB2 against Mac mini and PC over LAN and Internet. Happy to split this into two PRs, change the defaults, or adjust anything you'd rather see done differently. These fixes have greatly improved my own productivity when using OpenParsec for remote desktop control.