### PR TITLE
Auto reconnect and stuck input fix

### DIFF
--- a/OpenParsec/CParsec.swift
+++ b/OpenParsec/CParsec.swift
@@ -159,6 +159,7 @@ protocol ParsecService {
 	func sendWheelMsg(x: Int32, y: Int32)
 	func sendUserData(type: ParsecUserDataType, message: Data)
 	func sendReleaseMessage()
+	func reconnect(_ peerID: String) -> ParsecStatus
 	func pause(video: Bool, audio: Bool) -> ParsecStatus
 	func resume() -> ParsecStatus
 	func updateHostVideoConfig()
@@ -284,6 +285,11 @@ class CParsec {
 
 	static func sendReleaseMessage() {
 		parsecImpl.sendReleaseMessage()
+	}
+
+	@discardableResult
+	static func reconnect(_ peerID: String) -> ParsecStatus {
+		return parsecImpl.reconnect(peerID)
 	}
 
 	@discardableResult

--- a/OpenParsec/GameController.swift
+++ b/OpenParsec/GameController.swift
@@ -89,12 +89,17 @@ class GamepadController {
 		for mouse in GCMouse.mice() {
 			mice.insert(mouse)
 			mouse.mouseInput?.leftButton.pressedChangedHandler = {(_: GCControllerButtonInput, _: Float, pressed: Bool) in
+				guard ParsecBackgroundManager.shared.hasActiveConnection else { return }
 				CParsec.sendMouseClickMessage(MOUSE_L, pressed)
 				}
 			mouse.mouseInput?.rightButton?.pressedChangedHandler = {(_: GCControllerButtonInput, _: Float, pressed: Bool) in
+				// pointer-lock toggles on the connect/disconnect view swap can synthesize a button edge
+				// with no real input — dont forward it unless a session is actually live
+				guard ParsecBackgroundManager.shared.hasActiveConnection else { return }
 				CParsec.sendMouseClickMessage(MOUSE_R, pressed)
 				}
 			mouse.mouseInput?.middleButton?.pressedChangedHandler = {(_: GCControllerButtonInput, _: Float, pressed: Bool) in
+				guard ParsecBackgroundManager.shared.hasActiveConnection else { return }
 				CParsec.sendMouseClickMessage(MOUSE_MIDDLE, pressed)
 				}
 			mouse.mouseInput?.mouseMovedHandler={(_: GCMouseInput, v: Float, v2: Float) in

--- a/OpenParsec/MainView.swift
+++ b/OpenParsec/MainView.swift
@@ -110,6 +110,49 @@ struct MainView: View {
 							Text(refreshTime)
 								.multilineTextAlignment(.center)
 								.opacity(0.5)
+							if let lastHost = ParsecBackgroundManager.shared.lastHostname,
+							   ParsecBackgroundManager.shared.lastPeerId != nil {
+								VStack(spacing: 0) {
+									HStack {
+										VStack(alignment: .leading, spacing: 4) {
+											Text("Last connected")
+												.font(.system(size: 12))
+												.opacity(0.5)
+											Text(lastHost)
+												.font(.system(size: 16, weight: .medium))
+										}
+										Spacer()
+										Button(action: reconnectLastHost) {
+											Text("Reconnect")
+												.foregroundColor(.white)
+												.padding(.horizontal, 12)
+												.padding(.vertical, 6)
+												.background(Color("AccentColor"))
+												.cornerRadius(8)
+										}
+										Button(action: clearLastHost) {
+											Image(systemName: "xmark")
+												.foregroundColor(Color("Foreground"))
+												.opacity(0.5)
+												.padding(8)
+										}
+									}
+									.padding()
+									HStack {
+										Toggle("Auto connect on launch", isOn: Binding(
+											get: { SettingsHandler.autoConnectOnLaunch },
+											set: { SettingsHandler.autoConnectOnLaunch = $0 }
+										))
+										.font(.system(size: 13))
+										.opacity(0.7)
+									}
+									.padding(.horizontal)
+									.padding(.bottom, 10)
+								}
+								.frame(maxWidth: 400)
+								.background(Rectangle().fill(Color("BackgroundCard")))
+								.cornerRadius(8)
+							}
 							ForEach(hosts) { i in
 								ZStack {
 									VStack {
@@ -362,6 +405,22 @@ struct MainView: View {
 				refreshHosts()
 			}
 		}
+
+		if SettingsHandler.autoConnectOnLaunch && !isConnecting && !ParsecBackgroundManager.shared.hasActiveConnection, ParsecBackgroundManager.shared.lastPeerId != nil {
+			reconnectLastHost()
+		}
+	}
+
+	func reconnectLastHost() {
+		guard let peerId = ParsecBackgroundManager.shared.lastPeerId else { return }
+		let hostname = ParsecBackgroundManager.shared.lastHostname ?? peerId
+		let user = UserInfo(id: 0, name: "", warp: false, team_id: "")
+		let stub = IdentifiableHostInfo(id: peerId, hostname: hostname, user: user, connections: 0)
+		connectTo(stub)
+	}
+
+	func clearLastHost() {
+		ParsecBackgroundManager.shared.disableAutoReconnect()
 	}
 
 	func refreshHosts() {
@@ -516,8 +575,11 @@ struct MainView: View {
 	}
 
 	func connectTo(_ who: IdentifiableHostInfo) {
+		pollTimer?.invalidate()
+		pollTimer = nil
 		CParsec.initialize()
 		connectingToName = who.hostname
+		ParsecBackgroundManager.shared.lastHostname = who.hostname
 		withAnimation { isConnecting = true }
 
 		var status = CParsec.connect(who.id)
@@ -554,6 +616,7 @@ struct MainView: View {
 	func logout() {
 		removeFromKeychain(key: GLBDataModel.shared.SessionKeyChainKey)
 		NetworkHandler.clinfo = nil
+		ParsecBackgroundManager.shared.disableAutoReconnect()
 		if let c = controller {
 			c.setView(.login)
 		}

--- a/OpenParsec/MainView.swift
+++ b/OpenParsec/MainView.swift
@@ -544,9 +544,6 @@ struct MainView: View {
 						guard let statusCode = (response as? HTTPURLResponse)?.statusCode else { return }
 						let decoder = JSONDecoder()
 
-						print("/friendships: \(statusCode)")
-						print(String(data: data, encoding: .utf8)!)
-
 						if statusCode == 200 { // 200 OK
 							guard let info: FriendInfoList = try? decoder.decode(FriendInfoList.self, from: data) else { return }
 							friends.removeAll()

--- a/OpenParsec/MainView.swift
+++ b/OpenParsec/MainView.swift
@@ -94,7 +94,7 @@ struct MainView: View {
 						}
 					}
 					Spacer()
-					Button(action: { inSettings = true }, label: { Image(systemName: "gear") })
+					Button(action: { withAnimation(.easeInOut(duration: 0.24)) { inSettings = true } }, label: { Image(systemName: "gear") })
 						.padding()
 				}
 				.foregroundColor(Color("AccentColor"))

--- a/OpenParsec/MainView.swift
+++ b/OpenParsec/MainView.swift
@@ -32,6 +32,8 @@ struct MainView: View {
 
 	@State var inSettings: Bool = false
 
+	@State private var lastHostShown: String?
+
 	var busy: Bool {
 		isConnecting || isRefreshing || inSettings
 	}
@@ -110,8 +112,7 @@ struct MainView: View {
 							Text(refreshTime)
 								.multilineTextAlignment(.center)
 								.opacity(0.5)
-							if let lastHost = ParsecBackgroundManager.shared.lastHostname,
-							   ParsecBackgroundManager.shared.lastPeerId != nil {
+							if let lastHost = lastHostShown {
 								VStack(spacing: 0) {
 									HStack {
 										VStack(alignment: .leading, spacing: 4) {
@@ -394,6 +395,7 @@ struct MainView: View {
 	}
 
 	func initView() {
+		lastHostShown = ParsecBackgroundManager.shared.lastPeerId != nil ? ParsecBackgroundManager.shared.lastHostname : nil
 		refreshHosts()
 		refreshSelf()
 		refreshFriends()
@@ -421,6 +423,7 @@ struct MainView: View {
 
 	func clearLastHost() {
 		ParsecBackgroundManager.shared.disableAutoReconnect()
+		lastHostShown = nil
 	}
 
 	func refreshHosts() {

--- a/OpenParsec/ParsecBackgroundManager.swift
+++ b/OpenParsec/ParsecBackgroundManager.swift
@@ -14,7 +14,6 @@ class ParsecBackgroundManager {
 	}
 	private var didDisconnectDueToBackground = false
 	private(set) var isReconnecting = false
-	var isAttemptingReconnect = false
 	var reconnectAttempts = 0
 	var isPaused = false
 	weak var glkViewController: GLKViewController?
@@ -89,6 +88,5 @@ class ParsecBackgroundManager {
 		lastPeerId = nil
 		lastHostname = nil
 		reconnectAttempts = 0
-		isAttemptingReconnect = false
 	}
 }

--- a/OpenParsec/ParsecBackgroundManager.swift
+++ b/OpenParsec/ParsecBackgroundManager.swift
@@ -44,8 +44,6 @@ class ParsecBackgroundManager {
 		didDisconnectDueToBackground = false
 		isReconnecting = false
 		isPaused = false
-		reconnectAttempts = 0
-		isAttemptingReconnect = false
 	}
 
 	func connectionDidEnd() {

--- a/OpenParsec/ParsecBackgroundManager.swift
+++ b/OpenParsec/ParsecBackgroundManager.swift
@@ -6,9 +6,16 @@ class ParsecBackgroundManager {
 	static let shared = ParsecBackgroundManager()
 
 	private(set) var hasActiveConnection = false
-	private var lastPeerId: String?
+	private(set) var lastPeerId: String? {
+		didSet { UserDefaults.standard.set(lastPeerId, forKey: "lastConnectedPeerId") }
+	}
+	var lastHostname: String? {
+		didSet { UserDefaults.standard.set(lastHostname, forKey: "lastConnectedHostname") }
+	}
 	private var didDisconnectDueToBackground = false
 	private(set) var isReconnecting = false
+	var isAttemptingReconnect = false
+	var reconnectAttempts = 0
 	var isPaused = false
 	weak var glkViewController: GLKViewController?
 
@@ -27,6 +34,8 @@ class ParsecBackgroundManager {
 	}
 
 	private init() {
+		lastPeerId = UserDefaults.standard.string(forKey: "lastConnectedPeerId")
+		lastHostname = UserDefaults.standard.string(forKey: "lastConnectedHostname")
 	}
 
 	func connectionDidStart(peerId: String) {
@@ -35,6 +44,8 @@ class ParsecBackgroundManager {
 		didDisconnectDueToBackground = false
 		isReconnecting = false
 		isPaused = false
+		reconnectAttempts = 0
+		isAttemptingReconnect = false
 	}
 
 	func connectionDidEnd() {
@@ -78,5 +89,8 @@ class ParsecBackgroundManager {
 		didDisconnectDueToBackground = false
 		isReconnecting = false
 		lastPeerId = nil
+		lastHostname = nil
+		reconnectAttempts = 0
+		isAttemptingReconnect = false
 	}
 }

--- a/OpenParsec/ParsecBackgroundManager.swift
+++ b/OpenParsec/ParsecBackgroundManager.swift
@@ -42,6 +42,7 @@ class ParsecBackgroundManager {
 		lastPeerId = peerId
 		didDisconnectDueToBackground = false
 		isReconnecting = false
+		reconnectAttempts = 0
 		isPaused = false
 	}
 

--- a/OpenParsec/ParsecSDKBridge.swift
+++ b/OpenParsec/ParsecSDKBridge.swift
@@ -120,6 +120,9 @@ class ParsecSDKBridge: ParsecService {
 	func disconnect() {
 
 		pollGeneration += 1
+		// release any held input (incl. mouse buttons) WHILE still connected, before teardown —
+		// otherwise a half-sent click leaves a button stuck on the host (right-button = context menu)
+		sendReleaseMessage()
 		ParsecClientDisconnect(_parsec)
 		audio_clear(&_audio)
 

--- a/OpenParsec/ParsecSDKBridge.swift
+++ b/OpenParsec/ParsecSDKBridge.swift
@@ -49,6 +49,7 @@ class ParsecSDKBridge: ParsecService {
 	public var pngCursor: Bool = false
 	private var pollGeneration = 0
 	var didSetResolution = false
+	private var didReleaseOnConnect = false
 
 	public var mouseInfo = MouseInfo()
 
@@ -107,6 +108,7 @@ class ParsecSDKBridge: ParsecService {
 		parsecClientCfg.pngCursor = false
 
 		self.startBackgroundTask()
+		didReleaseOnConnect = false
 
 		let status = ParsecClientConnect(_parsec, &parsecClientCfg, NetworkHandler.clinfo?.session_id, peerID)
 
@@ -167,6 +169,14 @@ class ParsecSDKBridge: ParsecService {
 		let ans = ParsecClientGetStatus(_parsec, &pcs)
 		self.hostHeight = Float(pcs.decoder.0.height)
 		self.hostWidth = Float(pcs.decoder.0.width)
+
+		// on the first live OK of a session, clear any input the host still holds from before
+		// (a stuck right-button = context menu). teardown releases get dropped before they send;
+		// this one goes over a known-live socket.
+		if ans == PARSEC_OK && !didReleaseOnConnect {
+			didReleaseOnConnect = true
+			sendReleaseMessage()
+		}
 
 		return ans
 	}

--- a/OpenParsec/ParsecSDKBridge.swift
+++ b/OpenParsec/ParsecSDKBridge.swift
@@ -47,8 +47,7 @@ class ParsecSDKBridge: ParsecService {
 	public var netProtocol: Int32 = 1
 	public var mediaContainer: Int32 = 0
 	public var pngCursor: Bool = false
-	private var audioWork: DispatchWorkItem?
-	private var eventWork: DispatchWorkItem?
+	private var pollGeneration = 0
 	var didSetResolution = false
 
 	public var mouseInfo = MouseInfo()
@@ -120,8 +119,7 @@ class ParsecSDKBridge: ParsecService {
 
 	func disconnect() {
 
-		audioWork?.cancel()
-		eventWork?.cancel()
+		pollGeneration += 1
 		ParsecClientDisconnect(_parsec)
 		audio_clear(&_audio)
 
@@ -130,8 +128,7 @@ class ParsecSDKBridge: ParsecService {
 
 	func reconnect(_ peerID: String) -> ParsecStatus {
 		sendReleaseMessage()
-		audioWork?.cancel()
-		eventWork?.cancel()
+		pollGeneration += 1
 		ParsecClientDisconnect(_parsec)
 		audio_clear(&_audio)
 		ParsecBackgroundManager.shared.connectionDidEnd()
@@ -520,20 +517,21 @@ class ParsecSDKBridge: ParsecService {
 
 	func startBackgroundTask() {
 
+		pollGeneration += 1
+		let generation = pollGeneration
+
 		let audio = DispatchWorkItem { [weak self] in
-			while let self = self, !(self.audioWork?.isCancelled ?? true) {
+			while let self = self, self.pollGeneration == generation {
 				self.pollAudio()
 			}
 		}
 
 		let event = DispatchWorkItem { [weak self] in
-			while let self = self, !(self.eventWork?.isCancelled ?? true) {
+			while let self = self, self.pollGeneration == generation {
 				self.pollEvent()
 			}
 		}
 
-		audioWork = audio
-		eventWork = event
 		DispatchQueue.global().async(execute: audio)
 		DispatchQueue.global().async(execute: event)
 	}

--- a/OpenParsec/ParsecSDKBridge.swift
+++ b/OpenParsec/ParsecSDKBridge.swift
@@ -128,6 +128,20 @@ class ParsecSDKBridge: ParsecService {
 		ParsecBackgroundManager.shared.connectionDidEnd()
 	}
 
+	func reconnect(_ peerID: String) -> ParsecStatus {
+		sendReleaseMessage()
+		audioWork?.cancel()
+		eventWork?.cancel()
+		ParsecClientDisconnect(_parsec)
+		audio_clear(&_audio)
+		ParsecBackgroundManager.shared.connectionDidEnd()
+		let status = connect(peerID)
+		if status != PARSEC_OK && status != PARSEC_CONNECTING {
+			ParsecBackgroundManager.shared.connectionDidEnd()
+		}
+		return status
+	}
+
 	func sendReleaseMessage() {
 		var msg = ParsecMessage()
 		msg.type = MESSAGE_RELEASE

--- a/OpenParsec/ParsecView.swift
+++ b/OpenParsec/ParsecView.swift
@@ -132,7 +132,7 @@ struct ParsecView: View {
 		self.controller = controller
 
 		let save = SettingsHandler.saveSessionSettings
-		_muted = State(initialValue: save ? SettingsHandler.savedMuted : false)
+		_muted = State(initialValue: SettingsHandler.startMuted || (save && SettingsHandler.savedMuted))
 		_zoomEnabled = State(initialValue: save ? SettingsHandler.savedZoomEnabled : false)
 		_constantFps = State(initialValue: save ? SettingsHandler.savedConstantFps : false)
 		_resolutions = State(initialValue: ParsecResolution.resolutions)
@@ -358,6 +358,7 @@ struct ParsecView: View {
 
 		CParsec.applyConfig()
 		CParsec.setMuted(muted)
+		if muted { CParsec.pause(video: false, audio: true) }
 		parsecViewController.setZoomEnabled(zoomEnabled)
 
 		if SettingsHandler.saveSessionSettings {

--- a/OpenParsec/ParsecView.swift
+++ b/OpenParsec/ParsecView.swift
@@ -8,14 +8,17 @@ struct ParsecStatusBar: View {
 	@State var metricInfo: String = "Loading..."
 	@Binding var showDCAlert: Bool
 	@Binding var DCAlertText: String
+	@Binding var isReconnecting: Bool
+	@State var reconnectStartTime: Date = Date()
 	@State var parsecViewController: ParsecViewController?
 	@State var wasDisconnected: Bool = true
 	let timer = Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()
 
-	init(showMenu: Binding<Bool>, showDCAlert: Binding<Bool>, DCAlertText: Binding<String>, parsecViewController: ParsecViewController) {
+	init(showMenu: Binding<Bool>, showDCAlert: Binding<Bool>, DCAlertText: Binding<String>, parsecViewController: ParsecViewController, isReconnecting: Binding<Bool>) {
 		_showMenu = showMenu
 		_showDCAlert = showDCAlert
 		_DCAlertText = DCAlertText
+		_isReconnecting = isReconnecting
 		self.parsecViewController = parsecViewController
 	}
 
@@ -56,6 +59,12 @@ struct ParsecStatusBar: View {
 				return
 			}
 
+			if status == PARSEC_CONNECTING && isReconnecting {
+				if Date().timeIntervalSince(reconnectStartTime) < 15 {
+					return
+				}
+			}
+
 			// PiP: connection died (screen lock killed GPU). Kill connection+audio once,
 			// subsequent polls exit via isMarkedForReconnect above.
 			var pipActive = false
@@ -71,10 +80,33 @@ struct ParsecStatusBar: View {
 				return
 			}
 
+			if SettingsHandler.autoReconnect, let peerId = ParsecBackgroundManager.shared.lastPeerId {
+				let mgr = ParsecBackgroundManager.shared
+				if mgr.reconnectAttempts < 3 {
+					mgr.reconnectAttempts += 1
+					mgr.isAttemptingReconnect = true
+					isReconnecting = true
+					reconnectStartTime = Date()
+					parsecViewController?.resetKeyState()
+					CParsec.reconnect(peerId)
+					return
+				}
+				mgr.reconnectAttempts = 0
+				mgr.isAttemptingReconnect = false
+				isReconnecting = false
+			}
+
 			wasDisconnected = true
 			DCAlertText = "Disconnected (code \(status.rawValue))"
 			showDCAlert = true
 			return
+		}
+
+		if isReconnecting {
+			ParsecBackgroundManager.shared.reconnectAttempts = 0
+			ParsecBackgroundManager.shared.isAttemptingReconnect = false
+			isReconnecting = false
+			ParsecBackgroundManager.shared.glkViewController?.isPaused = false
 		}
 
 		if showMenu || SettingsHandler.alwaysShowStatus {
@@ -110,6 +142,7 @@ struct ParsecView: View {
 	@State var muted: Bool = false
 	@State var preferH265: Bool = true
 	@State var constantFps = false
+	@State var isReconnecting: Bool = false
 
 	@State var resolutions: [ParsecResolution]
 	@State var bitrates: [Int]
@@ -151,7 +184,19 @@ struct ParsecView: View {
 				.zIndex(1)
 				.prefersPersistentSystemOverlaysHidden()
 
-			ParsecStatusBar(showMenu: $showMenu, showDCAlert: $showDCAlert, DCAlertText: $DCAlertText, parsecViewController: parsecViewController)
+			ParsecStatusBar(showMenu: $showMenu, showDCAlert: $showDCAlert, DCAlertText: $DCAlertText, parsecViewController: parsecViewController, isReconnecting: $isReconnecting)
+
+			if isReconnecting {
+				VStack(spacing: 12) {
+					ActivityIndicator(isAnimating: .constant(true), style: .large, tint: .white)
+					Text("Reconnecting...")
+						.font(.system(size: 16, weight: .medium))
+						.foregroundColor(.white)
+				}
+				.frame(maxWidth: .infinity, maxHeight: .infinity)
+				.background(Color.black.opacity(0.6))
+				.zIndex(10)
+			}
 
 			VStack {
 				if !hideOverlay {
@@ -303,7 +348,25 @@ struct ParsecView: View {
 		}
 		.statusBarHidden(SettingsHandler.hideStatusBar)
 		.alert(isPresented: $showDCAlert) {
-			Alert(title: Text(DCAlertText), dismissButton: .default(Text("Close"), action: {disconnect()}))
+			Alert(title: Text(DCAlertText),
+				  primaryButton: .default(Text("Reconnect"), action: {
+					guard let peerId = ParsecBackgroundManager.shared.lastPeerId else {
+						disconnect()
+						return
+					}
+					showDCAlert = false
+					isReconnecting = true
+					ParsecBackgroundManager.shared.reconnectAttempts = 0
+					parsecViewController.resetKeyState()
+					CParsec.reconnect(peerId)
+				  }),
+				  secondaryButton: .cancel(Text("Close"), action: {disconnect()}))
+		}
+		.onChange(of: isReconnecting) { reconnecting in
+			if !reconnecting {
+				CParsec.setMuted(muted)
+				if muted { CParsec.pause(video: false, audio: true) }
+			}
 		}
 		.onAppear(perform: post)
 		.onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("ParsecBackgroundDisconnect"))) { _ in

--- a/OpenParsec/ParsecView.swift
+++ b/OpenParsec/ParsecView.swift
@@ -84,7 +84,6 @@ struct ParsecStatusBar: View {
 				let mgr = ParsecBackgroundManager.shared
 				if mgr.reconnectAttempts < 3 {
 					mgr.reconnectAttempts += 1
-					mgr.isAttemptingReconnect = true
 					isReconnecting = true
 					reconnectStartTime = Date()
 					parsecViewController?.resetKeyState()
@@ -92,7 +91,6 @@ struct ParsecStatusBar: View {
 					return
 				}
 				mgr.reconnectAttempts = 0
-				mgr.isAttemptingReconnect = false
 				isReconnecting = false
 			}
 
@@ -104,7 +102,6 @@ struct ParsecStatusBar: View {
 
 		if isReconnecting {
 			ParsecBackgroundManager.shared.reconnectAttempts = 0
-			ParsecBackgroundManager.shared.isAttemptingReconnect = false
 			isReconnecting = false
 			ParsecBackgroundManager.shared.glkViewController?.isPaused = false
 		}

--- a/OpenParsec/ParsecView.swift
+++ b/OpenParsec/ParsecView.swift
@@ -111,6 +111,10 @@ struct ParsecStatusBar: View {
 			ParsecBackgroundManager.shared.reconnectAttempts = 0
 			isReconnecting = false
 			ParsecBackgroundManager.shared.glkViewController?.isPaused = false
+			// SDK forgets stream dims on reconnect, re-send them so the frame fills not corners
+			if let vc = parsecViewController {
+				CParsec.setFrame(vc.view.bounds.width, vc.view.bounds.height, UIScreen.main.scale)
+			}
 		}
 
 		if showMenu || SettingsHandler.alwaysShowStatus {

--- a/OpenParsec/ParsecView.swift
+++ b/OpenParsec/ParsecView.swift
@@ -13,13 +13,15 @@ struct ParsecStatusBar: View {
 	@State var parsecViewController: ParsecViewController?
 	@State var wasDisconnected: Bool = true
 	let timer = Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()
+	let onSilentDisconnect: () -> Void
 
-	init(showMenu: Binding<Bool>, showDCAlert: Binding<Bool>, DCAlertText: Binding<String>, parsecViewController: ParsecViewController, isReconnecting: Binding<Bool>) {
+	init(showMenu: Binding<Bool>, showDCAlert: Binding<Bool>, DCAlertText: Binding<String>, parsecViewController: ParsecViewController, isReconnecting: Binding<Bool>, onSilentDisconnect: @escaping () -> Void) {
 		_showMenu = showMenu
 		_showDCAlert = showDCAlert
 		_DCAlertText = DCAlertText
 		_isReconnecting = isReconnecting
 		self.parsecViewController = parsecViewController
+		self.onSilentDisconnect = onSilentDisconnect
 	}
 
 	var body: some View {
@@ -95,8 +97,13 @@ struct ParsecStatusBar: View {
 			}
 
 			wasDisconnected = true
-			DCAlertText = "Disconnected (code \(status.rawValue))"
-			showDCAlert = true
+			if SettingsHandler.autoReconnect && !SettingsHandler.errorPrompts {
+				// silent: auto-reconnect spent its retries, dont nag with an alert
+				onSilentDisconnect()
+			} else {
+				DCAlertText = "Disconnected (code \(status.rawValue))"
+				showDCAlert = true
+			}
 			return
 		}
 
@@ -181,7 +188,7 @@ struct ParsecView: View {
 				.zIndex(1)
 				.prefersPersistentSystemOverlaysHidden()
 
-			ParsecStatusBar(showMenu: $showMenu, showDCAlert: $showDCAlert, DCAlertText: $DCAlertText, parsecViewController: parsecViewController, isReconnecting: $isReconnecting)
+			ParsecStatusBar(showMenu: $showMenu, showDCAlert: $showDCAlert, DCAlertText: $DCAlertText, parsecViewController: parsecViewController, isReconnecting: $isReconnecting, onSilentDisconnect: { disconnect() })
 
 			if isReconnecting {
 				VStack(spacing: 12) {

--- a/OpenParsec/ParsecView.swift
+++ b/OpenParsec/ParsecView.swift
@@ -82,7 +82,7 @@ struct ParsecStatusBar: View {
 				return
 			}
 
-			if SettingsHandler.autoReconnect, let peerId = ParsecBackgroundManager.shared.lastPeerId {
+			if SettingsHandler.autoReconnect, !isPermanentFailure(status), let peerId = ParsecBackgroundManager.shared.lastPeerId {
 				let mgr = ParsecBackgroundManager.shared
 				if mgr.reconnectAttempts < 3 {
 					mgr.reconnectAttempts += 1
@@ -97,11 +97,11 @@ struct ParsecStatusBar: View {
 			}
 
 			wasDisconnected = true
-			if SettingsHandler.autoReconnect && !SettingsHandler.errorPrompts {
+			if SettingsHandler.autoReconnect && !SettingsHandler.errorPrompts && !isPermanentFailure(status) {
 				// silent: auto-reconnect spent its retries, dont nag with an alert
 				onSilentDisconnect()
 			} else {
-				DCAlertText = "Disconnected (code \(status.rawValue))"
+				DCAlertText = readableStatus(status)
 				showDCAlert = true
 			}
 			return
@@ -120,6 +120,34 @@ struct ParsecStatusBar: View {
 		if showMenu || SettingsHandler.alwaysShowStatus {
 			let str = String.fromBuffer(&pcs.decoder.0.name.0, length: 16)
 			metricInfo = "Decode \(String(format: "%.2f", pcs.`self`.metrics.0.decodeLatency))ms    Encode \(String(format: "%.2f", pcs.`self`.metrics.0.encodeLatency))ms    Network \(String(format: "%.2f", pcs.`self`.metrics.0.networkLatency))ms    Bitrate \(String(format: "%.2f", pcs.`self`.metrics.0.bitrate))Mbps    \(pcs.decoder.0.h265 ? "H265" : "H264") \(pcs.decoder.0.width)x\(pcs.decoder.0.height) \(pcs.decoder.0.color444 ? "4:4:4" : "4:2:0") \(str)"
+		}
+	}
+
+	func isPermanentFailure(_ s: ParsecStatus) -> Bool {
+		switch s {
+		case WS_ERR_AUTH, WS_ERR_TEAM_DEACTIVATED,
+			 CONNECT_WRN_DECLINED, CONNECT_WRN_NO_PERMISSION, CONNECT_WRN_NO_ROOM,
+			 HOST_WRN_KICKED, HOST_WRN_SHUTDOWN,
+			 NETWORK_ERR_UNSUPPORTED, SERVER_ERR_DISPLAY, SERVER_ERR_RESOLUTION:
+			return true
+		default:
+			return false
+		}
+	}
+
+	func readableStatus(_ s: ParsecStatus) -> String {
+		switch s {
+		case WS_ERR_AUTH:               return "Authentication failed"
+		case WS_ERR_TEAM_DEACTIVATED:   return "Team account deactivated"
+		case CONNECT_WRN_DECLINED:      return "Host declined the connection"
+		case CONNECT_WRN_NO_PERMISSION: return "No permission to connect"
+		case CONNECT_WRN_NO_ROOM:       return "Host is full"
+		case HOST_WRN_KICKED:           return "Kicked by the host"
+		case HOST_WRN_SHUTDOWN:         return "Host shut down"
+		case NETWORK_ERR_UNSUPPORTED:   return "Network not supported"
+		case SERVER_ERR_DISPLAY:        return "Host has no display"
+		case SERVER_ERR_RESOLUTION:     return "Host resolution problem"
+		default:                        return "Disconnected (code \(s.rawValue))"
 		}
 	}
 }

--- a/OpenParsec/ParsecViewController.swift
+++ b/OpenParsec/ParsecViewController.swift
@@ -429,6 +429,12 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate, ParsecTouchI
 		repeatKeyCode = -1
 	}
 
+	func resetKeyState() {
+		stopKeyRepeat()
+		optCmdRemapActive = false
+		altKeyHeld = false
+	}
+
 	private func isModifierKey(_ keyCode: UIKeyboardHIDUsage) -> Bool {
 		switch keyCode {
 		case .keyboardLeftControl, .keyboardLeftShift, .keyboardLeftAlt, .keyboardLeftGUI,

--- a/OpenParsec/ParsecViewController.swift
+++ b/OpenParsec/ParsecViewController.swift
@@ -428,6 +428,13 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate, ParsecTouchI
 		}
 	}
 
+	override func pressesCancelled(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+		// iOS sends this instead of pressesEnded when a press is interrupted (e.g. backgrounding
+		// mid-hold) — without cleanup the host keeps keys held (stuck paste, stuck opt/cmd remap).
+		CParsec.sendReleaseMessage()
+		resetKeyState()
+	}
+
 	private func startKeyRepeat(keyCode: Int) {
 		stopKeyRepeat()
 		repeatKeyCode = keyCode

--- a/OpenParsec/ParsecViewController.swift
+++ b/OpenParsec/ParsecViewController.swift
@@ -880,6 +880,10 @@ extension ParsecViewController: UIGestureRecognizerDelegate {
 	@objc func handleTwoFingerTap(_ gestureRecognizer: UITapGestureRecognizer) {
 		// A two-finger TAP is a right click; if the fingers moved (pinch/scroll) it wasn't a tap.
 		if twoFingerDidMove { return }
+		// dont leak a right-click to the host while backgrounding (app switch) or after a disconnect
+		guard UIApplication.shared.applicationState == .active,
+			  ParsecBackgroundManager.shared.hasActiveConnection else { return }
+
 		let location: CGPoint
 		switch SettingsHandler.rightClickPosition {
 		case .firstFinger:

--- a/OpenParsec/ParsecViewController.swift
+++ b/OpenParsec/ParsecViewController.swift
@@ -1016,6 +1016,32 @@ extension ParsecViewController: UIKeyInput, UITextInputTraits {
 		}
 	}
 
+	// passthrough keyboard: send raw input, dont let iOS autocorrect / smart-substitute / inject text
+	var autocorrectionType: UITextAutocorrectionType {
+		get { .no }
+		set { }
+	}
+	var spellCheckingType: UITextSpellCheckingType {
+		get { .no }
+		set { }
+	}
+	var smartQuotesType: UITextSmartQuotesType {
+		get { .no }
+		set { }
+	}
+	var smartDashesType: UITextSmartDashesType {
+		get { .no }
+		set { }
+	}
+	var smartInsertDeleteType: UITextSmartInsertDeleteType {
+		get { .no }
+		set { }
+	}
+	var autocapitalizationType: UITextAutocapitalizationType {
+		get { .none }
+		set { }
+	}
+
 	override var canBecomeFirstResponder: Bool {
 		return true
 	}

--- a/OpenParsec/ParsecViewController.swift
+++ b/OpenParsec/ParsecViewController.swift
@@ -72,6 +72,8 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate, ParsecTouchI
 	var onKeyboardVisibilityChanged: ((Bool) -> Void)?
 	var scrollView: UIScrollView!
 	var contentView: UIView!
+	var lastLaidOutWidth: CGFloat = 0
+	var lastLaidOutHeight: CGFloat = 0
 
 	override var prefersPointerLocked: Bool {
 		return true
@@ -317,6 +319,23 @@ class ParsecViewController: UIViewController, UIScrollViewDelegate, ParsecTouchI
         if keyboardVisible {
             reloadInputViews()
         }
+	}
+
+	override func viewDidLayoutSubviews() {
+		super.viewDidLayoutSubviews()
+		// glkView/contentView get sized from possibly-stale bounds in viewDidLoad and have no
+		// autoresizing, so the stream renders in a corner until a rotation re-applies the size.
+		// re-apply once layout settles; skip while zoomed so we dont stomp pan/zoom.
+		guard scrollView != nil, scrollView.zoomScale == 1.0 else { return }
+		let w = view.bounds.width
+		let h = view.bounds.height
+		guard w > 0, h > 0, w != lastLaidOutWidth || h != lastLaidOutHeight else { return }
+		lastLaidOutWidth = w
+		lastLaidOutHeight = h
+		glkView.updateSize(width: w, height: h)
+		contentView.frame.size = CGSize(width: w, height: h)
+		scrollView.contentSize = CGSize(width: w, height: h)
+		CParsec.setFrame(w, h, UIScreen.main.scale)
 	}
 
 	override func viewDidAppear(_ animated: Bool) {

--- a/OpenParsec/ParsecViewController.swift
+++ b/OpenParsec/ParsecViewController.swift
@@ -883,6 +883,12 @@ extension ParsecViewController: UIGestureRecognizerDelegate {
 		// dont leak a right-click to the host while backgrounding (app switch) or after a disconnect
 		guard UIApplication.shared.applicationState == .active,
 			  ParsecBackgroundManager.shared.hasActiveConnection else { return }
+		// ignore taps landing in the bottom home-indicator strip — thats the app-switch / bottom-bar
+		// system-gesture zone where a stray two-finger touch (eg while typing) gets read as a right-click
+		let tapY = gestureRecognizer.location(in: view).y
+		if tapY > view.bounds.height - max(view.safeAreaInsets.bottom, 24) {
+			return
+		}
 
 		let location: CGPoint
 		switch SettingsHandler.rightClickPosition {

--- a/OpenParsec/SceneDelegate.swift
+++ b/OpenParsec/SceneDelegate.swift
@@ -29,11 +29,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 		if ParsecBackgroundManager.shared.isPaused {
 			ParsecBackgroundManager.shared.glkViewController?.isPaused = false
 			CParsec.resume()
-			// drop any keys the host still thinks are held from a mid-hold background (stuck paste/cmd)
-			CParsec.sendReleaseMessage()
 			DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
 				ParsecBackgroundManager.shared.isPaused = false
 			}
+		}
+		// drop any input the host still thinks is held after ANY interruption — Control Center, the
+		// notification shade, a bottom-bar tap, or a brief sleep/unlock all resign+reactivate WITHOUT a
+		// full background (isPaused stays false), so the paused-only path above misses them and a
+		// stranded button (right = context menu) survives the resume. releasing nothing held is a no-op.
+		if ParsecBackgroundManager.shared.hasActiveConnection {
+			CParsec.sendReleaseMessage()
 		}
 		ParsecBackgroundManager.shared.sceneDidBecomeActive()
 	}

--- a/OpenParsec/SceneDelegate.swift
+++ b/OpenParsec/SceneDelegate.swift
@@ -29,6 +29,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 		if ParsecBackgroundManager.shared.isPaused {
 			ParsecBackgroundManager.shared.glkViewController?.isPaused = false
 			CParsec.resume()
+			// drop any keys the host still thinks are held from a mid-hold background (stuck paste/cmd)
+			CParsec.sendReleaseMessage()
 			DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
 				ParsecBackgroundManager.shared.isPaused = false
 			}

--- a/OpenParsec/SettingsHandler.swift
+++ b/OpenParsec/SettingsHandler.swift
@@ -20,6 +20,8 @@ struct SettingsHandler {
 	@AppStorage("alwaysShowStatus") public static var alwaysShowStatus: Bool = false
 	@AppStorage("enablePiP") public static var enablePiP: Bool = false
 	@AppStorage("startMuted") public static var startMuted: Bool = false
+	@AppStorage("autoReconnect") public static var autoReconnect: Bool = true
+	@AppStorage("autoConnectOnLaunch") public static var autoConnectOnLaunch: Bool = false
 
 	@AppStorage("saveSessionSettings") public static var saveSessionSettings: Bool = true
 	@AppStorage("savedZoomEnabled") public static var savedZoomEnabled: Bool = false

--- a/OpenParsec/SettingsHandler.swift
+++ b/OpenParsec/SettingsHandler.swift
@@ -19,6 +19,7 @@ struct SettingsHandler {
 	@AppStorage("showKeyboardButton") public static var showKeyboardButton: Bool = true
 	@AppStorage("alwaysShowStatus") public static var alwaysShowStatus: Bool = false
 	@AppStorage("enablePiP") public static var enablePiP: Bool = false
+	@AppStorage("startMuted") public static var startMuted: Bool = false
 
 	@AppStorage("saveSessionSettings") public static var saveSessionSettings: Bool = true
 	@AppStorage("savedZoomEnabled") public static var savedZoomEnabled: Bool = false

--- a/OpenParsec/SettingsHandler.swift
+++ b/OpenParsec/SettingsHandler.swift
@@ -21,6 +21,7 @@ struct SettingsHandler {
 	@AppStorage("enablePiP") public static var enablePiP: Bool = false
 	@AppStorage("startMuted") public static var startMuted: Bool = false
 	@AppStorage("autoReconnect") public static var autoReconnect: Bool = true
+	@AppStorage("errorPrompts") public static var errorPrompts: Bool = false
 	@AppStorage("autoConnectOnLaunch") public static var autoConnectOnLaunch: Bool = false
 
 	@AppStorage("saveSessionSettings") public static var saveSessionSettings: Bool = true

--- a/OpenParsec/SettingsView.swift
+++ b/OpenParsec/SettingsView.swift
@@ -176,12 +176,12 @@ struct SettingsView: View {
 								Toggle("", isOn: $autoReconnect)
 									.frame(width: 80)
 							}
-							CatItem("Error Prompts") {
-								Toggle("", isOn: $errorPrompts)
-									.frame(width: 80)
+							if autoReconnect {
+								CatItem("Reconnect Error Prompts") {
+									Toggle("", isOn: $errorPrompts)
+										.frame(width: 80)
+								}
 							}
-							.disabled(!autoReconnect)
-							.opacity(autoReconnect ? 1 : 0.4)
 							CatItem("Save Session Settings") {
 								Toggle("", isOn: $saveSessionSettings)
 									.frame(width: 80)

--- a/OpenParsec/SettingsView.swift
+++ b/OpenParsec/SettingsView.swift
@@ -22,6 +22,7 @@ struct SettingsView: View {
 	@AppStorage("alwaysShowStatus") var alwaysShowStatus: Bool = false
 	@AppStorage("enablePiP") var enablePiP: Bool = false
 	@AppStorage("startMuted") var startMuted: Bool = false
+	@AppStorage("autoReconnect") var autoReconnect: Bool = true
 
 	let resolutionChoices: [Choice<ParsecResolution>]
 
@@ -168,6 +169,10 @@ struct SettingsView: View {
 							}
 							CatItem("Start Muted") {
 								Toggle("", isOn: $startMuted)
+									.frame(width: 80)
+							}
+							CatItem("Auto Reconnect") {
+								Toggle("", isOn: $autoReconnect)
 									.frame(width: 80)
 							}
 							CatItem("Save Session Settings") {

--- a/OpenParsec/SettingsView.swift
+++ b/OpenParsec/SettingsView.swift
@@ -45,7 +45,6 @@ struct SettingsView: View {
 					.edgesIgnoringSafeArea(.all)
 			}
 		}
-		.animation(.linear(duration: 0.24))
 
 		ZStack {
 			if visible {
@@ -197,17 +196,17 @@ struct SettingsView: View {
 				.background(Rectangle().fill(Color("BackgroundGray")))
 				.cornerRadius(8)
 				.padding()
-				.animation(.none)
 			}
 		}
         .preferredColorScheme(appScheme)
 		.scaleEffect(visible ? 1 : 0, anchor: .zero)
-		.animation(.easeInOut(duration: 0.24))
 	}
 
 	func saveAndExit() {
 		// SettingsHandler.renderer = renderer
-		visible = false
+		withAnimation(.easeInOut(duration: 0.24)) {
+			visible = false
+		}
 	}
 
 	func getVersionInfo() -> String {

--- a/OpenParsec/SettingsView.swift
+++ b/OpenParsec/SettingsView.swift
@@ -21,6 +21,7 @@ struct SettingsView: View {
 	@AppStorage("saveSessionSettings") var saveSessionSettings: Bool = true
 	@AppStorage("alwaysShowStatus") var alwaysShowStatus: Bool = false
 	@AppStorage("enablePiP") var enablePiP: Bool = false
+	@AppStorage("startMuted") var startMuted: Bool = false
 
 	let resolutionChoices: [Choice<ParsecResolution>]
 
@@ -163,6 +164,10 @@ struct SettingsView: View {
 							}
 							CatItem("Picture in Picture") {
 								Toggle("", isOn: $enablePiP)
+									.frame(width: 80)
+							}
+							CatItem("Start Muted") {
+								Toggle("", isOn: $startMuted)
 									.frame(width: 80)
 							}
 							CatItem("Save Session Settings") {

--- a/OpenParsec/SettingsView.swift
+++ b/OpenParsec/SettingsView.swift
@@ -23,6 +23,7 @@ struct SettingsView: View {
 	@AppStorage("enablePiP") var enablePiP: Bool = false
 	@AppStorage("startMuted") var startMuted: Bool = false
 	@AppStorage("autoReconnect") var autoReconnect: Bool = true
+	@AppStorage("errorPrompts") var errorPrompts: Bool = false
 
 	let resolutionChoices: [Choice<ParsecResolution>]
 
@@ -175,6 +176,12 @@ struct SettingsView: View {
 								Toggle("", isOn: $autoReconnect)
 									.frame(width: 80)
 							}
+							CatItem("Error Prompts") {
+								Toggle("", isOn: $errorPrompts)
+									.frame(width: 80)
+							}
+							.disabled(!autoReconnect)
+							.opacity(autoReconnect ? 1 : 0.4)
 							CatItem("Save Session Settings") {
 								Toggle("", isOn: $saveSessionSettings)
 									.frame(width: 80)

--- a/OpenParsec/TouchHandlingView.swift
+++ b/OpenParsec/TouchHandlingView.swift
@@ -31,22 +31,19 @@ class TouchController {
 
 		let parsecTap = ParsecMouseButton(rawValue: UInt32(typeOfTap))
 
+		// send press+release back-to-back. the old 20ms async release could be orphaned by a
+		// reconnect/disconnect landing in that window, leaving the button (esp. right) stuck on the
+		// host — which pops a context menu that survives the transition.
 		if SettingsHandler.cursorMode == .direct {
 			let x = Int32(location.x)
 			let y = Int32(location.y)
 
-			// Send the mouse input to the host
-			// add release delay in case some games ignore instant key release
 			CParsec.sendMouseMessage(parsecTap, x, y, true)
-			DispatchQueue.global().asyncAfter(deadline: .now() + 0.02) {
-				CParsec.sendMouseMessage(parsecTap, x, y, false)
-			}
+			CParsec.sendMouseMessage(parsecTap, x, y, false)
 
 		} else {
 			CParsec.sendMouseClickMessage(parsecTap, true)
-			DispatchQueue.global().asyncAfter(deadline: .now() + 0.02) {
-				CParsec.sendMouseClickMessage(parsecTap, false)
-			}
+			CParsec.sendMouseClickMessage(parsecTap, false)
 		}
 	}
 


### PR DESCRIPTION
New feature
When stream drops, client retries with a timeout and a retry budget instead of dumping you back to the host list. User disconnects stay disconnected. host offline skip retrying, and disconnect reasons should be shown in readable form instead of jsut a status code. Added a "Last connected" card on the main screen and an optional auto-connect on launch

I also smuggled some input fixes from the same work, releasing held keys and buttons on foreground resume, avoiding right-click when backgrounding or disconnecting, and sending mouse clicks atomic so press can't be orphaned from its own release.

For everything else, see the commits