### PR TITLE
Session status and audio session exclusivity

### DIFF
--- a/OpenParsec/AppDelegate.swift
+++ b/OpenParsec/AppDelegate.swift
@@ -1,10 +1,13 @@
 import UIKit
+import AVFoundation
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 	func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 		// Override point for customization after application launch.
 		UTMViewControllerPatches.patchAll()
+		// dont interrupt music / other apps audio, mix instead
+		try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [.mixWithOthers])
 		return true
 	}
 

--- a/OpenParsec/ParsecSDKBridge.swift
+++ b/OpenParsec/ParsecSDKBridge.swift
@@ -232,6 +232,10 @@ class ParsecSDKBridge: ParsecService {
 			handleUserDataEvent(event: e.userData)
 		} else if e.type == CLIENT_EVENT_STREAM {
 			print("[stream] s=\(e.stream.stream) status=\(e.stream.status.rawValue)")
+		} else if e.type == CLIENT_EVENT_BLOCKED {
+			DispatchQueue.main.async { DataManager.model.isBlocked = true }
+		} else if e.type == CLIENT_EVENT_UNBLOCKED {
+			DispatchQueue.main.async { DataManager.model.isBlocked = false }
 		}
 	}
 

--- a/OpenParsec/ParsecView.swift
+++ b/OpenParsec/ParsecView.swift
@@ -234,6 +234,16 @@ struct ParsecView: View {
 				.zIndex(10)
 			}
 
+			if dataModel.isBlocked {
+				Text("Host is using the machine")
+					.foregroundColor(.white)
+					.padding(.horizontal, 16)
+					.padding(.vertical, 10)
+					.background(Color("BackgroundPrompt").opacity(0.85))
+					.cornerRadius(8)
+					.zIndex(3)
+			}
+
 			VStack {
 				if !hideOverlay {
 					HStack {

--- a/OpenParsec/ParsecView.swift
+++ b/OpenParsec/ParsecView.swift
@@ -119,7 +119,7 @@ struct ParsecStatusBar: View {
 
 		if showMenu || SettingsHandler.alwaysShowStatus {
 			let str = String.fromBuffer(&pcs.decoder.0.name.0, length: 16)
-			metricInfo = "Decode \(String(format: "%.2f", pcs.`self`.metrics.0.decodeLatency))ms    Encode \(String(format: "%.2f", pcs.`self`.metrics.0.encodeLatency))ms    Network \(String(format: "%.2f", pcs.`self`.metrics.0.networkLatency))ms    Bitrate \(String(format: "%.2f", pcs.`self`.metrics.0.bitrate))Mbps    \(pcs.decoder.0.h265 ? "H265" : "H264") \(pcs.decoder.0.width)x\(pcs.decoder.0.height) \(pcs.decoder.0.color444 ? "4:4:4" : "4:2:0") \(str)"
+			metricInfo = "Decode \(String(format: "%.2f", pcs.`self`.metrics.0.decodeLatency))ms    Encode \(String(format: "%.2f", pcs.`self`.metrics.0.encodeLatency))ms    Network \(String(format: "%.2f", pcs.`self`.metrics.0.networkLatency))ms    Bitrate \(String(format: "%.2f", pcs.`self`.metrics.0.bitrate))Mbps    RTx \(pcs.`self`.metrics.0.fastRTs + pcs.`self`.metrics.0.slowRTs)    Queue \(pcs.`self`.metrics.0.queuedFrames)    \(pcs.decoder.0.h265 ? "H265" : "H264") \(pcs.decoder.0.width)x\(pcs.decoder.0.height) \(pcs.decoder.0.color444 ? "4:4:4" : "4:2:0") \(str)"
 		}
 	}
 

--- a/OpenParsec/PictureInPictureManager.swift
+++ b/OpenParsec/PictureInPictureManager.swift
@@ -53,7 +53,7 @@ class PictureInPictureManager: NSObject {
 		self.glContext = glContext
 		self.glkViewController = glkViewController
 
-		try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
+		try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [.mixWithOthers])
 		try? AVAudioSession.sharedInstance().setActive(true)
 
 		let layer = AVSampleBufferDisplayLayer()

--- a/OpenParsec/Shared.swift
+++ b/OpenParsec/Shared.swift
@@ -72,6 +72,7 @@ class SharedModel: ObservableObject {
 	@Published var constantFps = false
 	@Published var output = "none"
 	@Published var displayConfigs: [ParsecDisplayConfig] = []
+	@Published var isBlocked = false
 
 }
 


### PR DESCRIPTION
to not take audio session exclusivley so connecting won't kills music that was playing, this mixes instead
Applies to app delegate and pip mode

then status overlay, see commit
